### PR TITLE
chore: remove line numbers for example node where they are not needed

### DIFF
--- a/docs/src/guides/posting-transactions/arweave-js.md
+++ b/docs/src/guides/posting-transactions/arweave-js.md
@@ -1,13 +1,13 @@
 ## Installing the arweave-js Package
 
-```console
+```console:no-line-numbers
 npm install --save arweave
 ```
 
 ## Initializing arweave-js
 Direct Layer 1 transactions are posted using the `arweave-js` library.
 
-```js
+```js:no-line-numbers
 import Arweave from 'arweave';
 import fs from "fs";
 
@@ -20,7 +20,7 @@ const arweave = Arweave.init({});
 
 ## Posting a wallet-to-wallet Transaction
 A basic transaction to move AR tokens from one wallet address to another.
-```js
+```js:no-line-numbers
 //  create a wallet-to-wallet transaction sending 10.5AR to the target address
 let transaction = await arweave.createTransaction({
   target: '1seRanklLU_1VTGkEk7P0xAwMJfA7owA1JHW5KyZKlY',
@@ -36,7 +36,7 @@ const response = await arweave.transactions.post(transaction);
 
 ## Posting a Data Transaction
 This example illustrates how load a file from disk and create a transaction to store its data on the network. You can find the current price the network is charging at [https://ar-fees.arweave.dev](https://ar-fees.arweave.dev)
-```js
+```js:no-line-numbers
 // load the data from disk
 const imageData = fs.readFileSync(`iamges/myImage.png`);
 

--- a/docs/src/guides/posting-transactions/bundlr.md
+++ b/docs/src/guides/posting-transactions/bundlr.md
@@ -2,18 +2,18 @@
 Layer 2 transactions are posted using `bundlr-network/client`. 
 
 Add the package using npm:
-```console
+```console:no-line-numbers
 npm install @bundlr-network/client
 ```
 or yarn:
-```console
+```console:no-line-numbers
 yarn add @bundlr-network/client
 ```
 
 ## Initializing Bundlr Network Client
 A difference between posting Layer 1 and bundled Layer 2 transactions is that when using bundlr you must make a deposit on the bundlr node ahead of time. This deposit can be made using AR tokens or a variety of other crypto currencies. Another difference is that the bundlr service guarantees your data will arrive on chain.
 
-```js
+```js:no-line-numbers
 import Bundlr from '@bundlr-network/client';
 import fs from "fs";
 
@@ -26,7 +26,7 @@ const bundlr = new Bundlr("http://node1.bundlr.network", "arweave", key);
 
 ## Posting a Bundled Transaction
 
-```js
+```js:no-line-numbers
 // load the data from disk
 const imageData = fs.readFileSync(`images/myImage.png`);
 

--- a/docs/src/guides/posting-transactions/dispatch.md
+++ b/docs/src/guides/posting-transactions/dispatch.md
@@ -1,7 +1,7 @@
 ## Dispatching a Transaction
 This can be done without any package dependences for the client app. As long as the user has a browser wallet active and the data is less than 100KB, dispatched transactions are free and guaranteed to be confirmed on the network.
 
-```js
+```js:no-line-numbers
 // use arweave-js to create a transaction
 let tx = await arweave.createTransaction({ data:"Hello World!" })
 


### PR DESCRIPTION
Removing line numbers from code blocks as it results in less visual noise. I recommend only using line numbers when it's important to reference a specific line in the code from the accompanying written description.