### PR TITLE
chore: update organization of posting transactions index

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -67,7 +67,22 @@ module.exports = {
           },
           {
             text: `Posting Transactions`,
-            link: `/concepts/postTransaction`
+            link: `/concepts/post-transactions`,
+            collapsible: true,
+            children: [
+              {
+                text: 'arweave-js',
+                link: '/guides/posting-transactions/arweave-js'
+              },
+              {
+                text: 'bundlr.network',
+                link: '/guides/posting-transactions/bundlr'
+              },
+              {
+                text: 'dispatch',
+                link: '/guides/posting-transactions/dispatch'
+              }
+            ]
           },
           {
             text: 'Profit Sharing Tokens (PSTs)',

--- a/docs/src/concepts/README.md
+++ b/docs/src/concepts/README.md
@@ -9,7 +9,7 @@ Describing the building blocks of the permaweb.
 - [Path Manifests](manifests.md)
 - [Permaweb](permaweb.md)
 - [Permaweb Applications](permawebApplications.md)
-- [Posting Transactions](postTransaction.md)
+- [Posting Transactions](post-transactions.md)
 - [Profit Sharing Tokens](psts.md)
 - [Querying Transactions](queryTransations.md)
 - [SmartWeave](smartweave.md)

--- a/docs/src/concepts/post-transactions.md
+++ b/docs/src/concepts/post-transactions.md
@@ -6,7 +6,7 @@ There are several ways to post transactions to Arweave. Each has its own unique 
 <img src="https://arweave.net/PQnMySn9x7vHhrlkBRZhwH93bZfeehPzp_c03diLmjk" width="550">
 
 ::: info <img src="https://arweave.net/UO8dtoT9P0txwVR9HrHDTVVLWDtMANpzszWl7b8KdP0" width="20" />  Info
-Transactions posted directly to the Arweave network may take 2 or more minutes to confirm.
+Transactions posted directly to the Arweave network may take 2 or more minutes to confirm. Arweave has a protocol limit of 1000 transactions per block. If your transaction needs exceed this capacity, please consider using a bundling service.
 :::
 
 ::: tip <img src="https://arweave.net/blzzObMx8QvyrPTdLPGV3m-NsnJ-QqBzvQIQzzZEfIk" width="20"> Guaranteed Transactions
@@ -51,3 +51,9 @@ When transactions are posted to bundlr.network they are also appear in the optim
 Another way to post bundled transactions is from the browser. While browsers enforce some constraints around the size of data that can be uploaded, browser based wallets are able to post transactions to bundlers. Arweave browser wallets implement a `dispatch()` API method. If you are posting small transactions (100KB or less) you can use the wallets `dispatch()` method to take advantage of bundled transactions even if `bundlr.network/client` isn't packaged with your application.
 
  An example of how to post a 100KB or less bundled transaction with an Arweave wallets `dispatch()` method can be found [in this guide](../guides/posting-transactions/dispatch.md).
+
+## Resources
+* [arweave-js](../guides/posting-transactions/arweave-js.md) example
+* [bundlr.network](../guides/posting-transactions/bundlr.md) example
+* [dispatch](../guides//posting-transactions/dispatch.md) example
+

--- a/docs/src/guides/posting-transactions/arweave-js.md
+++ b/docs/src/guides/posting-transactions/arweave-js.md
@@ -1,3 +1,5 @@
+# Posting Transactions using arweave-js
+Arweave native transactions can be posted directly to a node or gateway using the `arweave-js` package.
 ## Installing the arweave-js Package
 
 To install `arweave-js` run

--- a/docs/src/guides/posting-transactions/bundlr.md
+++ b/docs/src/guides/posting-transactions/bundlr.md
@@ -1,3 +1,6 @@
+# Posting Transactions using bundlr.network
+Posting transactions to bundlr.network can be accomplished using the `bundlr.network/client` javascript package. Bundling services enable guaranteed confirmation of posted transactions as well as supporting many thousands of transactions per block though the use of transaction bundles.
+
 ## Installing the bundlr.network/client
 To install `bundlr.network/client` run
 

--- a/docs/src/guides/posting-transactions/dispatch.md
+++ b/docs/src/guides/posting-transactions/dispatch.md
@@ -1,5 +1,7 @@
+# Posting a Transaction Using Dispatch
+Arweave Browser wallets have the concept of dispatching transactions. If the transaction is under 100KB in size it can be posted for free!
 ## Dispatching a Transaction
-This can be done without any package dependences for the client app. As long as the user has a browser wallet active and the data is less than 100KB, dispatched transactions are free and guaranteed to be confirmed on the network.
+This can be done without any package dependencies for the client app. As long as the user has a browser wallet active and the data is less than 100KB, dispatched transactions are free and guaranteed to be confirmed on the network.
 
 ```js:no-line-numbers
 // use arweave-js to create a transaction


### PR DESCRIPTION
Making the individual guides for posting transactions also available under the `Posting Transactions` snack in the `Core Concepts` for better locality of reference / discoverability.

![image](https://user-images.githubusercontent.com/3269261/213317197-bbbee78e-ede5-4272-835f-37aadedf0889.png)
