### PR TITLE
docs: reorganizing the index for posting transactions examples

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -123,7 +123,7 @@ module.exports = {
             link: '/guides/atomic-assets'
           },
           {
-            text: `CLI Deployment`,
+            text: `App Deployment`,
             collapsible: true,
             children: [
               {
@@ -150,21 +150,7 @@ module.exports = {
           },
           {
             text: `Posting Transactions`,
-            collapsible: true,
-            children: [
-              {
-                text: 'arweave-js',
-                link: '/guides/posting-transactions/arweave-js'
-              },
-              {
-                text: 'bundlr.network',
-                link: '/guides/posting-transactions/bundlr'
-              },
-              {
-                text: 'dispatch',
-                link: '/guides/posting-transactions/dispatch'
-              },
-            ]
+            link: `/guides/posting-transactions`
           },
           {
             text: `Deploying Path Manifests`,

--- a/docs/src/guides/README.md
+++ b/docs/src/guides/README.md
@@ -7,16 +7,14 @@ title: Permaweb Cookbook - Guides
 Snack-sized guides about different tools for development
 
 - [Atomic Assets](atomic-assets/index.md)
-- [Deployment: arkb](deployment/arkb.md)
-- [Deployment: bundlr-cli](deployment/bundlr-cli.md)
-- [Deployment: github-action](deployment/github-action.md)
+- [App Deployment: arkb](deployment/arkb.md)
+- [App Deployment: bundlr-cli](deployment/bundlr-cli.md)
+- [app Deployment: github-action](deployment/github-action.md)
 - [DNS Integration: server-side](dns-integration/server-side.md)
-- [Posting Transactions: arweave-js](posting-transactions/arweave-js.md)
-- [Posting Transactions: bundlr](posting-transactions/bundlr.md)
-- [Posting Transactions: dispatch](posting-transactions/dispatch.md)
-- [Querying Transactions](querying-arweave/queryingArweave.md)
-- [Querying Transactions: ArDB](querying-arweave/ardb.md)
-- [Querying Transactions: ar-gql](querying-arweave/ar-gql.md)
+- [Posting Transactions](posting-transactions/README.md)
+- [Querying Arweave](querying-arweave/queryingArweave.md)
+- - [ArDB](querying-arweave/ardb.md)
+- - [ar-gql](querying-arweave/ar-gql.md)
 - [SmartWeave: Warp](smartweave/warp/README.md)
 
 

--- a/docs/src/guides/posting-transactions/README.md
+++ b/docs/src/guides/posting-transactions/README.md
@@ -1,0 +1,5 @@
+Please the the examples attached to Posting Transactions Core Concept.
+
+* [arweave-js](/guides/posting-transactions/arweave-js.md) example
+* [bundlr.network](/guides/posting-transactions/bundlr.md) example
+* [dispatch](/guides//posting-transactions/dispatch.md) example


### PR DESCRIPTION
Currently when you expand one of the Post Transactions examples, it expands the cookbook index in two places which is confusing. To maintain a good locality of reference for new devs, the examples are located in close proximity to the "Posting Transactions" core concept. 

This PR makes that be their primary location and posts a link to them from the Guides section so they only expand the index in one place.

![image](https://user-images.githubusercontent.com/3269261/213516113-31064340-5f53-4483-bcb3-75ae730a5906.png)

