### PR TITLE
fix react and svetle links in the permawebApplications

### DIFF
--- a/docs/src/concepts/permawebApplications.md
+++ b/docs/src/concepts/permawebApplications.md
@@ -45,8 +45,8 @@ By leveraging modern web application frameworks and the [Path Manifest](./manife
 
 To learn more about creating and deploying Permaweb Apps, check out our starter kits in your favorite framework:
 
-* [React](../kits/react.md)
-* [Svelte](../kits/svelte.md)
+* [React](../kits/react/index.md)
+* [Svelte](../kits/svelte/index.md)
 
 ::: tip Missing my framework?
 Can't find your framework, why don't you contribute? [How to contribute to the cookbook](../getting-started/contributing.md)

--- a/docs/src/concepts/post-transactions.md
+++ b/docs/src/concepts/post-transactions.md
@@ -6,7 +6,7 @@ There are several ways to post transactions to Arweave. Each has its own unique 
 <img src="https://arweave.net/Z1eDDnz4kqxAkkzy6p5elMz-jKnlaVIletp-Tm6W8kQ" width="550">
 
 ::: tip <img src="https://arweave.net/blzzObMx8QvyrPTdLPGV3m-NsnJ-QqBzvQIQzzZEfIk" width="20"> Guaranteed Transactions
-If you are posting a high volume of transactions or you want your transactions to be confirmed immediately consider using a bundling service. Transactions posted via a bundler are confirmed immediately and available within milliseconds. The service holds onto the transactions until they are confirmed on-chain. If the transactions are not included in the most recent block the bundling service re-posts them with each new block until tye are confirmed. 
+If you are posting a high volume of transactions or you want your transactions to be confirmed immediately consider using a bundling service. Transactions posted via a bundler are confirmed immediately and available within milliseconds. The service holds onto the transactions until they are confirmed on-chain. If the transactions are not included in the most recent block the bundling service re-posts them with each new block until they are confirmed. 
 :::
 
 ## Direct Transactions


### PR DESCRIPTION
The links leading to the react and svetle starter kits from the permaweb applications page are broken. This PR fixes them.