### PR TITLE
Add missing landing pages for main topics

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -161,6 +161,7 @@ export default {
           },
           {
             text: 'DNS Integration',
+            link: '/guides/dns-integration/',
             collapsible: true,
             children: [{
               text: 'Server Side',
@@ -174,6 +175,7 @@ export default {
           },
           {
             text: `Deploying Apps`,
+            link: '/guides/deployment/',
             collapsible: true,
             children: [
               {
@@ -231,6 +233,7 @@ export default {
           },
           {
             text: 'SmartWeave',
+            link: '/guides/smartweave/',
             collapsible: true,
             children: [
               {
@@ -265,6 +268,7 @@ export default {
           },
           {
             text: `Testing`,
+            link: '/guides/testing/',
             collapsible: true,
             children: [
               {

--- a/docs/src/guides/deployment/index.md
+++ b/docs/src/guides/deployment/index.md
@@ -1,0 +1,7 @@
+# Deploying Apps
+
+Learn more about:
+
+- [arkb](./arkb)
+- [Bundlr](./bundlr-cli)
+- [GitHub Action](./github-action)

--- a/docs/src/guides/dns-integration/index.md
+++ b/docs/src/guides/dns-integration/index.md
@@ -1,0 +1,6 @@
+# DNS Integration
+
+Learn more about:
+
+- [Server Side](./server-side)
+- [Spheron](./spheron)

--- a/docs/src/guides/smartweave/index.md
+++ b/docs/src/guides/smartweave/index.md
@@ -1,0 +1,7 @@
+# SmartWeave
+
+Learn more about:
+
+- [Atomic Tokens](/guides/atomic-tokens/intro)
+- [Vouch](/guides/vouch)
+- [warp](./warp/intro)

--- a/docs/src/guides/testing/index.md
+++ b/docs/src/guides/testing/index.md
@@ -1,0 +1,5 @@
+# Testing
+
+Learn more about:
+
+- [arlocal](./arlocal)


### PR DESCRIPTION
Add landing pages for:

- Deploying Apps
- DNS Integration
- SmartWeave
- Testing

This creates a url route for these sections.