### PR TITLE
Update table background colors

### DIFF
--- a/docs/src/.vuepress/styles/index.scss
+++ b/docs/src/.vuepress/styles/index.scss
@@ -11,7 +11,8 @@
   --c-brand: #ff5f15;
   --c-text: #242424;
   --c-bg: #f2f2f2;
-  --c-bg-light: #ffffff;
+  --c-bg-light: #e0e2e3;
+  --c-bg-dark: #d2d2d4;
   --c-bg-rgb: 242, 242, 242;
 
   --c-topbar-bg: #DCDCDC;
@@ -29,8 +30,9 @@ html.dark {
   --c-brand: #ff5f15;
   --c-text: #ffffff;
   --c-bg: #242424;
+  --c-bg-light: #323131;
+  --c-bg-dark: #424141;
   --c-bg-rgb: 36, 36, 36;
-  --c-bg-light: #585858;
 
   --c-topbar-bg: #2E2E2E;
 


### PR DESCRIPTION
Improve the legibility of tables in the documentation.

Old:
<img width="766" alt="Screenshot 2023-03-13 at 23 53 12" src="https://user-images.githubusercontent.com/121981731/224755926-05180cf7-2560-47fe-80fc-cd5f02654a16.png">

New:
<img width="764" alt="Screenshot 2023-03-13 at 23 53 07" src="https://user-images.githubusercontent.com/121981731/224755901-34a80bb6-2037-4982-aa0b-b227b4a0e278.png">
