### PR TITLE
docs: remove references to L1 and L2 from bundle docs

### DIFF
--- a/docs/src/concepts/bundlers.md
+++ b/docs/src/concepts/bundlers.md
@@ -1,6 +1,6 @@
 # Bundling Services
 ---
-With bundling services users can post their data transactions to a centralized service to have it "bundled" together with other users transactions and posted as a single Arweave transaction in an upcoming Arweave block.
+With bundling services users can post their data transactions to a bundling service to have it "bundled" together with other users transactions and posted as a single Arweave transaction in an upcoming Arweave block.
 
 ### Posting to a bundling service
 ---

--- a/docs/src/concepts/bundles.md
+++ b/docs/src/concepts/bundles.md
@@ -4,9 +4,9 @@
 
 ---
 
-Bundles are groups of transactions or data items to be uploaded to Arweave. 
+A transaction bundle is a special type of Arweave transaction. It enables multiple other transactions and/or data items to be bundled inside it. Because transaction bundles contain many nested transactions they are key to Arweave's ability to scale to thousands of transactions per second.
 
-Bundles are submitted to a layer 2 network, such as [Bundlr](https://bundlr.network), who post the grouped transactions as a single 'bundle' to Arweave (Layer 1).
+Users submit transactions to a bundling service, such as [Bundlr.network](https://bundlr.network), which combines them into a 'bundle' with other transactions and posts them to the network.
 
 ### How Do Bundles Help Arweave?
 
@@ -14,30 +14,29 @@ Bundles are submitted to a layer 2 network, such as [Bundlr](https://bundlr.netw
 
 #### Availability
 
-Bundled transactions are guaranteed to be settled on Arweave.
+Bundling services guarantee that bundled transactions are reliably posted to Arweave without dropping.
 
-The transaction ID of the bundle is immediately made available, meaning the data can instantly be accessed as if it was already on the Arweave network.
-
+Transaction IDs of the bundled transactions are immediately made available, meaning the data can instantly be accessed as if it was already on the Arweave network.
 
 #### Reliability 
 
-Transactions posted to Arweave can occasionally fail to confirm due to a number of reasons, such as high network activity. In these instances transactions can become **orphaned**, i.e. stuck in the mempool and eventually removed.
+Transactions posted to Arweave can occasionally fail to confirm (resulting in a dropped transaction) due to a number of reasons, such as high network activity. In these instances transactions can become **orphaned**, i.e. stuck in the mempool and eventually removed.
 
-Bundlers solve this problem by continually attempting to post your bundled data to Arweave, assuring that it does not fail or get stuck in the mempool. It also guarantees that **all** of your bundled data arrives together.
+Bundlers solve this problem by continually attempting to post bundled data to Arweave, assuring that it does not fail or get stuck in the mempool.
 
 #### Scalability 
 
-Bundles can store up to 2^256 transactions, each of which are settled as a single transaction on Arweave. This makes Arweave essentially infinitely scalable.
+Bundles can store up to 2<sup>256</sup> transactions, each of which are settled as a single transaction on Arweave. This makes Arweave blockspace scale to support almost any use case.
 
 #### Flexibility
 
-As bundles are handled by a layer 2 network, this opens up opportunity for different kinds of payment channels (such as eth, matic, solana) to pay for uploading data to Arweave.
+As bundling is handled by bundling services built on top of Arweave, it opens up the possibility of paying for storage with different currencies. [Bundlr.network](https://bundlr.network) supports payments in multiple tokens (such as ETH, MATIC, and SOL) for uploading data to Arweave.
 
 ### What are Nested Bundles?
 
 ---
 
-Bundles take data items to be uploaded to Arweave, and the data item itself can be a bundle.
+Bundles can include data items for uploading to Arweave and those data item can themselves be a bundle.
 
 This means it is possible to upload a bundle of bundles, or in other words **nested bundles**.
 


### PR DESCRIPTION
Trying to differentiate bundling services from Ethereum L2s as there are a number of key areas where the analogy breaks down.

1. L2's on ethereum perform some kind of rollup where the state of the side chain is compressed and posted to Ethereum. Arweave bundles do no such thing, every single transaction in a bundle appears as part of the native blockchain, there is no compression at work.

2. L2's on ethereum don't really scale, they quickly run into blockspace and have to rely on a fee-market to compete for transaction inclusion. Arweave bundles are not so limited. Everyone who wants to be in a bundle can have their data included. They never bid in a fee market for transaction inclusion, they just pay the network storage cost and bundlers markup. Everyone pays the exact same fee.