### PR TITLE
refactor: Update references from postTransaction.md to post-transactions.md

### DIFF
--- a/docs/src/guides/posting-transactions/arweave-js.md
+++ b/docs/src/guides/posting-transactions/arweave-js.md
@@ -81,6 +81,6 @@ while (!uploader.isComplete) {
 }
 ```
 ## Resources
-* For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/postTransaction.md) section of the cookbook.
+* For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/post-transactions.md) section of the cookbook.
 
 * For a more detailed description of all `arweave-js`'s features see the documentation [on github](https://github.com/ArweaveTeam/arweave-js)

--- a/docs/src/guides/posting-transactions/bundlr.md
+++ b/docs/src/guides/posting-transactions/bundlr.md
@@ -54,7 +54,7 @@ await tx.sign();
 await tx.upload();
 ```
 ## Resources
-* For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/postTransaction.md) section of the cookbook.
+* For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/post-transactions.md) section of the cookbook.
 
 * The full bundlr client docs can be found on the [bundlr.network website](https://docs.bundlr.network/docs/overview)
 

--- a/docs/src/guides/posting-transactions/dispatch.md
+++ b/docs/src/guides/posting-transactions/dispatch.md
@@ -21,4 +21,4 @@ console.log(result.id);
 ```
 
 ## Resources
-* For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/postTransaction.md) section of the cookbook.
+* For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/post-transactions.md) section of the cookbook.


### PR DESCRIPTION
In multiple places, the file "postTransaction.md" was mistakenly referenced. All references to "postTransaction.md" have been updated to "post-transactions.md", which is the correct name of the file that was intended to be referred to.