### PR TITLE
docs: bundlr no longer needs .default()

### DIFF
--- a/docs/src/getting-started/quick-starts/hw-nodejs.md
+++ b/docs/src/getting-started/quick-starts/hw-nodejs.md
@@ -34,7 +34,7 @@ import fs from "fs";
 
 const jwk = JSON.parse(fs.readFileSync("wallet.json").toString());
 
-const bundlr = new Bundlr.default(
+const bundlr = new Bundlr(
   "http://node2.bundlr.network",
   "arweave",
   jwk


### PR DESCRIPTION
Updated the bundlr import from:

```js
const bundlr = new Bundlr.default(
  "http://node2.bundlr.network",
  "arweave",
  jwk
);
```

to:

```js
const bundlr = new Bundlr(
  "http://node2.bundlr.network",
  "arweave",
  jwk
);
```