### PR TITLE
fix: disable slash redirect at build time.

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -430,5 +430,11 @@ export default {
         },
       },
     }),
-  ]
+  ],
+
+  async onInitialized(app) {
+    app.pages
+      .filter(page => page.path.slice(-1) === '/' && page.path !== '/')
+      .forEach(page => page.path += 'index.html');
+  },
 };


### PR DESCRIPTION
Before:
```
https://cookbook.arweave.dev/concepts/
```

After: 
```
https://cookbook.arweave.dev/concepts/index.html
```