### PR TITLE
Feat/sidebar accessibility

### DIFF
--- a/docs/src/.vuepress/components/Navbar.vue
+++ b/docs/src/.vuepress/components/Navbar.vue
@@ -117,7 +117,7 @@ onMounted(() => {
   --nav-h: 100px;
 
   @include media-breakpoint-down(md) {
-    --nav-h: 60px;
+    --nav-h: 50px;
   }
 }
 

--- a/docs/src/.vuepress/components/Sidebar.vue
+++ b/docs/src/.vuepress/components/Sidebar.vue
@@ -12,8 +12,7 @@ export default {
 
 <template>
   <aside class="cookbook-sidebar">
-    <SidebarItems />
-    <div class="col-1">
+    <div class="d-flex justify-content-between">
       <ToggleLanguageButton
         style="margin-right: 26px"
         class="d-block d-md-none"
@@ -21,9 +20,11 @@ export default {
       />
       <ToggleColorModeButton
         class="d-block d-md-none"
-        style="margin: 16px 0 0 auto; font-size: 0"
+        style="margin: 0 0.5rem 0 0; font-size: 0"
       />
     </div>
+    <hr class="d-block d-md-none" />
+    <SidebarItems />
   </aside>
   <div @click="$emit('close-sidebar')" class="cookbook-sidebar-overlay"></div>
 </template>


### PR DESCRIPTION
- Shift Language and Color toggles to top of sidebar
- Reduce navbar h by 10px in mobile devices to view toggle buttons effectively

Desktop and Laptop View:
![image](https://github.com/twilson63/permaweb-cookbook/assets/50047129/d5ba5514-282c-44b0-bc46-5b06ac7b434b)

Mobile device view:
![image](https://github.com/twilson63/permaweb-cookbook/assets/50047129/34f98251-864d-4848-93e8-148c7cc9652a)
