### PR TITLE
docs: fix references page

### DIFF
--- a/docs/src/references/README.md
+++ b/docs/src/references/README.md
@@ -1,1 +1,13 @@
+---
+title: Permaweb Cookbook - References
+---
+
 # References
+
+References for learning in depth about various topics like Bundling, GraphQL, and HTTP APIs.
+
+- [Bundling](bundling.md)
+- [GraphQL](gql.md)
+- [HTTP API](http-api)
+
+> Do you think a permaweb guide is missing? Create a issue at [Github](https://github.com/twilson63/permaweb-cookbook/issues) or consider [contributing](../getting-started/contributing.md)


### PR DESCRIPTION
Added the links to the subtopics for the references and the closing line of contributing to the GitHub repo of the cookbook.

Before - 
<img width="1438" alt="Screenshot 2023-11-07 at 1 00 21 AM" src="https://github.com/twilson63/permaweb-cookbook/assets/92804770/9cef9df4-11eb-4eb2-aaac-ca1e2f0d58f6">
