### PR TITLE
Remove knn3 gateway as search indexer

### DIFF
--- a/docs/src/guides/querying-arweave/search-indexing-service.md
+++ b/docs/src/guides/querying-arweave/search-indexing-service.md
@@ -27,7 +27,6 @@ For any custom needs or feature ideas, feel free to contact the Goldsky team thr
 Currently, the only service with this syntax is hosted Goldsky. If anybody is interested in hosting their own gateway with the same syntax, feel free to contact the [Goldsky](https://goldsky.com) for help.
 
 - [Goldsky Search Service](https://arweave-search.goldsky.com/graphql)
-- [KNN3 arseeding indexing](https://knn3-gateway.knn3.xyz/arseeding/graphql)
 
 ## Features
 


### PR DESCRIPTION
I think this was added accidentally to this page - it doesn't support the search API, at least with this endpoint: 

https://knn3-gateway.knn3.xyz/arseeding/graphql

None of the listed examples work in the endpoint here so it doesn't adhere with our loose 'Search Spec'. 

The reason this came up was that we had a few users email us about this, since the copy did say to ask Goldsky for support. 

```
query just_values {
  transactions(
    first: 10,
    tags: [
      {
        values: ["cat"]
      }
    ]
  ) 
  {
    edges {
      node {
        id
        tags {
          name
          value
        }
      }
    }
  }
}
```