### PR TITLE
This update brings the cookbook in line with the latest Irys SDK. Iry…

### DIFF
--- a/docs/src/concepts/post-transactions.md
+++ b/docs/src/concepts/post-transactions.md
@@ -41,7 +41,7 @@ Another difference when using a bundling service like [irys.xyz](https://irys.xy
 [irys.xyz](https://irys.xyz) allows clients to make deposits in a number of [supported crypto currencies](https://docs.irys.xyz/docs/currencies).
 
 ::: info
-When transactions are posted to irys.xyz they are also appear in the optimistic cache of connected gateways so they are available to query in a matter of milliseconds.
+When transactions are posted to irys.xyz they also appear in the optimistic cache of connected gateways so they are available to query in a matter of milliseconds.
 :::
 
 An example of how to post bundled transactions using `irys.xyz/sdk` can be found [in this guide](../guides/posting-transactions/irys.md).
@@ -54,7 +54,7 @@ An example of how to post a 100KB or less bundled transaction with an Arweave wa
 
 ## Resources
 
--   [arweave-js](../guides/posting-transactions/arweave-js.md) example
--   [irys.xyz](../guides/posting-transactions/irys.md) example
--   [dispatch](../guides/posting-transactions/dispatch.md) example
--   [arseeding-js](../guides/posting-transactions/arseeding-js.md) example
+- [arweave-js](../guides/posting-transactions/arweave-js.md) example
+- [irys.xyz](../guides/posting-transactions/irys.md) example
+- [dispatch](../guides/posting-transactions/dispatch.md) example
+- [arseeding-js](../guides/posting-transactions/arseeding-js.md) example

--- a/docs/src/es/getting-started/quick-starts/hw-cli.md
+++ b/docs/src/es/getting-started/quick-starts/hw-cli.md
@@ -8,7 +8,7 @@ Esta guía le guiará a través de la forma más simple de obtener datos en el p
 
 ## Requerimientos
 
--   [NodeJS](https://nodejs.org) LTS o superior
+- [NodeJS](https://nodejs.org) LTS o superior
 
 ## Descripción
 
@@ -37,5 +37,5 @@ echo "<h1>Hola Permaweb</h1>" > index.html
 ## Subir utilizando Irys
 
 ```sh
-irys upload index.html -c arweave -h https://node2.irys.xyz -w ./wallet.json
+irys upload index.html -c arweave -n mainnet -w ./wallet.json
 ```

--- a/docs/src/es/getting-started/quick-starts/hw-code.md
+++ b/docs/src/es/getting-started/quick-starts/hw-code.md
@@ -8,9 +8,9 @@ Esta guía le ayudará a lograr de forma rápida una página web estática HTML,
 
 ## Requisitos
 
--   [NodeJS](https://nodejs.org) LTS o superior
--   Conocimientos básicos de HTML, CSS y JavaScript
--   Un editor de texto (VS Code, Sublime, u otro similar)
+- [NodeJS](https://nodejs.org) LTS o superior
+- Conocimientos básicos de HTML, CSS y JavaScript
+- Un editor de texto (VS Code, Sublime, u otro similar)
 
 ## Descripción
 
@@ -104,7 +104,7 @@ Ahora que hay un sitio estático para desplegar, se puede comprobar para asegura
 El comando a continuación despliega el directorio `src` mientras también indica el archivo `index.html` como índice para los manifiestos (relativo a la ruta proporcionada al indicador `upload-dir`).
 
 ```sh
-irys upload-dir src -h https://node2.irys.xyz --index-file index.html -c arweave -w ./wallet.json
+irys upload-dir src -n mainnet --index-file index.html -c arweave -w ./wallet.json
 ```
 
 ## ¡¡Felicidades!!

--- a/docs/src/es/getting-started/quick-starts/hw-nodejs.md
+++ b/docs/src/es/getting-started/quick-starts/hw-nodejs.md
@@ -10,7 +10,7 @@ Con Arweave 2.6 solo permitiendo 1000 elementos por bloque, directamente subir a
 
 ## Requerimientos
 
--   [NodeJS](https://nodejs.org) LTS o mayor
+- [NodeJS](https://nodejs.org) LTS o mayor
 
 ## Descripción
 
@@ -34,11 +34,10 @@ node -e "require('arweave').init({}).wallets.generate().then(JSON.stringify).the
 
 ```js:no-line-numbers
 const jwk = JSON.parse(fs.readFileSync("wallet.json").toString());
-const url = "https://node2.irys.xyz";
 const token = "arweave";
 
 const irys = new Irys({
-	url, // URL of the node you want to connect to
+	network : "mainnet", // Irys network "mainnet" || "devnet"
 	token, // Token used for payment and signing
 	jwk, // Arweave wallet
 });
@@ -86,6 +85,6 @@ console.log(`https://arweave.net/${tx.id}`);
 
 ## Recursos
 
--   [Irys SDK](https://github.com/irys-xyz/js-sdk)
--   [Arweave JS SDK](https://github.com/ArweaveTeam/arweave-js)
--   [Irys Docs: Cargas gratuitas](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)
+- [Irys SDK](https://github.com/irys-xyz/js-sdk)
+- [Arweave JS SDK](https://github.com/ArweaveTeam/arweave-js)
+- [Irys Docs: Cargas gratuitas](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)

--- a/docs/src/es/guides/atomic-tokens/intro.md
+++ b/docs/src/es/guides/atomic-tokens/intro.md
@@ -24,7 +24,10 @@ async function main() {
   const wallet = JSON.parse(await import('fs')
     .then(fs => fs.readFileSync('./wallet.json', 'utf-8')))
 
-  const irys = new Irys({'https://node2.irys.xyz', 'arweave', wallet})
+  const irys = new Irys({
+			network: 'mainnet', // Irys network "mainnet" || "devnet"
+			'arweave',
+			wallet})
   const warp = WarpFactory.forMainnet()
 
   const data = `<h1>¡Hola Permaweb!</h1>`

--- a/docs/src/es/guides/deploying-manifests/irys.md
+++ b/docs/src/es/guides/deploying-manifests/irys.md
@@ -2,7 +2,7 @@
 locale: es
 ---
 
-### Irys CLI (Previously Bundlr)
+### Irys CLI
 
 ---
 

--- a/docs/src/es/guides/deployment/arkb.md
+++ b/docs/src/es/guides/deployment/arkb.md
@@ -60,7 +60,7 @@ arkb deploy [carpeta] --wallet [ruta a la cartera]
 
 Para implementar utilizando Irys, necesitarás <a href="#fund-irys">financiar un nodo Irys</a>.
 
-Irys node2 permite transacciones gratuitas de menos de 100kb.
+Irys permite transacciones gratuitas de menos de 100kb.
 
 Puedes añadir etiquetas identificables personalizadas a la implementación utilizando la sintaxis `nombre-etiqueta/valor-etiqueta`.
 

--- a/docs/src/es/guides/deployment/github-action.md
+++ b/docs/src/es/guides/deployment/github-action.md
@@ -33,39 +33,34 @@ npm install --save-dev arweave
 Crear archivo `deploy.mjs`
 
 ```js
-import Irys from '@irys/sdk'
-import { WarpFactory, defaultCacheOptions } from 'warp-contracts'
-import Arweave from 'arweave'
+import Irys from "@irys/sdk";
+import { WarpFactory, defaultCacheOptions } from "warp-contracts";
+import Arweave from "arweave";
 
-const ANT = '[TU CONTRATO ANT]'
-const DEPLOY_FOLDER = './dist'
-const IRYS_NODE = 'https://node2.irys.xyz'
+const ANT = "[TU CONTRATO ANT]";
+const DEPLOY_FOLDER = "./dist";
+const IRYS_NETWORK = "mainnet"; // 'mainnet' || 'devnet'
 
-const arweave = Arweave.init({ host: 'arweave.net', port: 443, protocol: 'https' })
-const jwk = JSON.parse(Buffer.from(process.env.PERMAWEB_KEY, 'base64').toString('utf-8'))
+const arweave = Arweave.init({ host: "arweave.net", port: 443, protocol: "https" });
+const jwk = JSON.parse(Buffer.from(process.env.PERMAWEB_KEY, "base64").toString("utf-8"));
 
-const irys = new Irys({ IRYS_NODE, 'arweave', jwk })
-const warp = WarpFactory.custom(
-  arweave,
-  defaultCacheOptions,
-  'mainnet'
-).useArweaveGateway().build()
+const irys = new Irys({ network: IRYS_NETWORK, token: "arweave", key: jwk });
+const warp = WarpFactory.custom(arweave, defaultCacheOptions, "mainnet").useArweaveGateway().build();
 
-const contract = warp.contract(ANT).connect(jwk)
+const contract = warp.contract(ANT).connect(jwk);
 // cargar carpeta
 const result = await irys.uploadFolder(DEPLOY_FOLDER, {
-  indexFile: 'index.html'
-})
-
+	indexFile: "index.html",
+});
 
 // actualizar ANT
 await contract.writeInteraction({
-  function: 'setRecord',
-  subDomain: '@',
-  transactionId: result.id
-})
+	function: "setRecord",
+	subDomain: "@",
+	transactionId: result.id,
+});
 
-console.log('Implementado Cookbook, por favor espera 20 - 30 minutos para que ArNS se actualice!')
+console.log("Implementado Cookbook, por favor espera 20 - 30 minutos para que ArNS se actualice!");
 ```
 
 ## Agregar script a package.json
@@ -92,22 +87,22 @@ Crear un archivo `deploy.yml` en la carpeta `.github/workflows`, este archivo in
 name: publicar
 
 on:
-    push:
-        branches:
-            - "main"
+  push:
+    branches:
+      - "main"
 
 jobs:
-    publicar:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 18.x
-            - run: yarn
-            - run: yarn deploy
-              env:
-                  KEY: ${{ secrets.PERMAWEB_KEY }}
+  publicar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - run: yarn
+      - run: yarn deploy
+        env:
+          KEY: ${{ secrets.PERMAWEB_KEY }}
 ```
 
 ## Resumen
@@ -121,7 +116,7 @@ base64 -i wallet.json | pbcopy
 Para que esta implementación funcione, deberás financiar la cuenta de Irys de esta billetera, asegúrate de tener algunos $AR en la billetera que vayas a usar, no mucho, tal vez .5 AR, luego usa la interfaz de línea de comandos de Irys para financiarla.
 
 ```console
-irys fund 250000000000 -h https://node2.irys.xyz -w wallet.json -t arweave
+irys fund 250000000000 -n mainnet -w wallet.json -t arweave
 ```
 
 ::: warning

--- a/docs/src/es/guides/deployment/irys-cli.md
+++ b/docs/src/es/guides/deployment/irys-cli.md
@@ -2,7 +2,7 @@
 locale: es
 ---
 
-# Irys CLI (Previously Bundlr)
+# Irys CLI
 
 ## Requisitos
 

--- a/docs/src/es/guides/posting-transactions/irys.md
+++ b/docs/src/es/guides/posting-transactions/irys.md
@@ -37,12 +37,11 @@ import fs from "fs";
 
 // carga el archivo de clave del monedero JWK desde el disco
 let key = JSON.parse(fs.readFileSync("walletFile.txt").toString());
-const url = "https://node1.irys.xyz";
 const token = "arweave";
 
 // inicializa el SDK de Irys
 const irys = new Irys({
-	url, // URL of the node you want to connect to
+	network : "mainnet", // Irys network "mainnet" || "devnet"
 	token, // Token used for payment and signing
 	key, // Arweave wallet
 });
@@ -69,8 +68,8 @@ try {
 
 ## Recursos
 
--   Para obtener una descripción general de todas las formas en que puedes publicar transacciones, consulta la sección [Publicación de Transacciones](../../concepts/post-transactions.md) del libro de recetas.
+- Para obtener una descripción general de todas las formas en que puedes publicar transacciones, consulta la sección [Publicación de Transacciones](../../concepts/post-transactions.md) del libro de recetas.
 
--   Puedes encontrar la documentación completa del cliente Irys en el [sitio web de Irys.xyz](http://docs.irys.xyz/developer-docs/irys-sdk)
+- Puedes encontrar la documentación completa del cliente Irys en el [sitio web de Irys.xyz](http://docs.irys.xyz/developer-docs/irys-sdk)
 
--   Un tutorial y taller para [subir una colección de NFT](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts) utilizando Irys.
+- Un tutorial y taller para [subir una colección de NFT](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts) utilizando Irys.

--- a/docs/src/es/guides/smartweave/warp/deploying-contracts.md
+++ b/docs/src/es/guides/smartweave/warp/deploying-contracts.md
@@ -39,10 +39,10 @@ async function deploy(initState, src) {
 
 Hay 4 formas en las que puedes desplegar un Contrato SmartWeave a través del SDK de Warp, estas opciones manejan diferentes casos de uso que un desarrollador puede encontrar.
 
--   Necesidad de desplegar el contrato con el código fuente al mismo tiempo.
--   Necesidad de desplegar un contrato donde el código fuente ya está en la permaweb.
--   Necesidad de desplegar un contrato a través del secuenciador y señalar algunos datos mediante un manifiesto de ruta.
--   Necesidad de desplegar un contrato a través de Irys y registrar ese contrato en el secuenciador.
+- Necesidad de desplegar el contrato con el código fuente al mismo tiempo.
+- Necesidad de desplegar un contrato donde el código fuente ya está en la permaweb.
+- Necesidad de desplegar un contrato a través del secuenciador y señalar algunos datos mediante un manifiesto de ruta.
+- Necesidad de desplegar un contrato a través de Irys y registrar ese contrato en el secuenciador.
 
 ::: tip
 Para obtener más información sobre los despliegues de Warp, consulta el Readme de GitHub para el proyecto. [https://github.com/warp-contracts/warp#deployment](https://github.com/warp-contracts/warp#deployment).
@@ -72,11 +72,11 @@ const { contractTxId, srcTxId } = await warp.deploy({
 });
 ```
 
--   wallet - debe ser el archivo de clave de Arweave (wallet.json) analizado como un objeto JSON que implementa la [Interfaz JWK](https://rfc-editor.org/rfc/rfc7517) o la cadena 'use_wallet'
--   initState - es un objeto JSON convertido en cadena
--   data - es opcional si deseas escribir datos como parte de tu despliegue
--   src - es el valor de la cadena o Uint8Array del código fuente del contrato
--   tags - es un array de objetos de nombre/valor `{name: string, value: string}[]`, [Aprende más sobre etiquetas](../../../concepts/tags.md)
+- wallet - debe ser el archivo de clave de Arweave (wallet.json) analizado como un objeto JSON que implementa la [Interfaz JWK](https://rfc-editor.org/rfc/rfc7517) o la cadena 'use_wallet'
+- initState - es un objeto JSON convertido en cadena
+- data - es opcional si deseas escribir datos como parte de tu despliegue
+- src - es el valor de la cadena o Uint8Array del código fuente del contrato
+- tags - es un array de objetos de nombre/valor `{name: string, value: string}[]`, [Aprende más sobre etiquetas](../../../concepts/tags.md)
 
 **deployFromSourceTx**
 
@@ -122,7 +122,10 @@ Utiliza el punto de enlace del Secuenciador del Gateway de Warp para indexar un 
 ```ts
 import Irys from '@irys/sdk'
 
-const irys = new Irys({'https://node2.irys.xyz', 'arweave', wallet})
+const irys = new Irys({
+		network: 'mainnet', // Irys network 'mainnet' || 'devnet'
+	 'arweave',
+	 wallet})
 const { id } = await irys.upload('Some Awesome Atomic Asset',  {
   tags: [{'Content-Type': 'text/plain' }]
 })

--- a/docs/src/es/kits/react/create-react-app.md
+++ b/docs/src/es/kits/react/create-react-app.md
@@ -8,15 +8,15 @@ Esta guía te guiará paso a paso para configurar tu entorno de desarrollo para 
 
 ## Requisitos previos
 
--   Conocimiento básico de TypeScript (no obligatorio) - [https://www.typescriptlang.org/docs/](Aprende TypeScript)
--   NodeJS v16.15.0 o superior - [https://nodejs.org/en/download/](Descargar NodeJS)
--   Conocimiento de ReactJS - [https://reactjs.org/](Aprende ReactJS)
--   Conocer git y comandos comunes de la terminal
+- Conocimiento básico de TypeScript (no obligatorio) - [https://www.typescriptlang.org/docs/](Aprende TypeScript)
+- NodeJS v16.15.0 o superior - [https://nodejs.org/en/download/](Descargar NodeJS)
+- Conocimiento de ReactJS - [https://reactjs.org/](Aprende ReactJS)
+- Conocer git y comandos comunes de la terminal
 
 ## Dependencias de desarrollo
 
--   TypeScript
--   NPM o Yarn Package Manager
+- TypeScript
+- NPM o Yarn Package Manager
 
 ## Pasos
 
@@ -240,7 +240,7 @@ Debes añadir AR a esta cartera y financiar tu cartera de Irys para poder cargar
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./build -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./build -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
   ...
 }
@@ -300,14 +300,14 @@ Si recibes este error `Not enough funds to send data`, tienes que financiar tu c
   <CodeGroupItem title="NPM">
   
 ```console:no-line-numbers
-irys fund 1479016 -h https://node1.irys.xyz -w wallet.json -c arweave
+irys fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>
   <CodeGroupItem title="YARN">
   
 ```console:no-line-numbers
-irys fund 1479016 -h https://node1.irys.xyz -w wallet.json -c arweave
+irys fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>

--- a/docs/src/es/kits/react/vite.md
+++ b/docs/src/es/kits/react/vite.md
@@ -8,15 +8,15 @@ Esta guía te guiará paso a paso para configurar tu entorno de desarrollo y con
 
 ## Requisitos previos
 
--   Conocimientos básicos de TypeScript (no obligatorio) - [https://www.typescriptlang.org/docs/](Aprende TypeScript)
--   NodeJS v16.15.0 o superior - [https://nodejs.org/en/download/](Descargar NodeJS)
--   Conocimientos de ReactJS - [https://reactjs.org/](Aprende ReactJS)
--   Conocimiento de git y comandos de terminal comunes
+- Conocimientos básicos de TypeScript (no obligatorio) - [https://www.typescriptlang.org/docs/](Aprende TypeScript)
+- NodeJS v16.15.0 o superior - [https://nodejs.org/en/download/](Descargar NodeJS)
+- Conocimientos de ReactJS - [https://reactjs.org/](Aprende ReactJS)
+- Conocimiento de git y comandos de terminal comunes
 
 ## Dependencias de desarrollo
 
--   TypeScript
--   NPM o Yarn Package Manager
+- TypeScript
+- NPM o Yarn Package Manager
 
 ## Pasos
 
@@ -255,7 +255,7 @@ Necesitarás agregar AR a esta billetera y fondear tu billetera de Irys para pod
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
   ...
 }

--- a/docs/src/es/kits/svelte/minimal.md
+++ b/docs/src/es/kits/svelte/minimal.md
@@ -8,17 +8,17 @@ Esta guía te guiará paso a paso para configurar tu entorno de desarrollo y cre
 
 ## Requisitos previos
 
--   Conocer TypeScript
--   NodeJS v18 o superior
--   Conocer Svelte - [https://svelte.dev](https://svelte.dev)
--   Conocer git y comandos de terminal comunes
+- Conocer TypeScript
+- NodeJS v18 o superior
+- Conocer Svelte - [https://svelte.dev](https://svelte.dev)
+- Conocer git y comandos de terminal comunes
 
 ## Dependencias de desarrollo
 
--   TypeScript
--   esbuild
--   w3
--   yarn `npm i -g yarn`
+- TypeScript
+- esbuild
+- w3
+- yarn `npm i -g yarn`
 
 ## Pasos
 
@@ -168,7 +168,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/es/kits/svelte/vite.md
+++ b/docs/src/es/kits/svelte/vite.md
@@ -211,7 +211,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "yarn build && irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "yarn build && irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/es/kits/vue/create-vue.md
+++ b/docs/src/es/kits/vue/create-vue.md
@@ -8,15 +8,15 @@ Esta guía proporcionará instrucciones paso a paso para configurar tu entorno d
 
 ## Requisitos previos
 
--   Conocimiento básico de TypeScript (no obligatorio) - [Aprende TypeScript](https://www.typescriptlang.org/docs/)
--   NodeJS v16.15.0 o superior - [Descarga NodeJS](https://nodejs.org/en/download/)
--   Conocimiento de Vue.js (preferiblemente Vue 3) - [Aprende Vue.js](https://vuejs.org/)
--   Conocimiento de git y comandos de terminal comunes
+- Conocimiento básico de TypeScript (no obligatorio) - [Aprende TypeScript](https://www.typescriptlang.org/docs/)
+- NodeJS v16.15.0 o superior - [Descarga NodeJS](https://nodejs.org/en/download/)
+- Conocimiento de Vue.js (preferiblemente Vue 3) - [Aprende Vue.js](https://vuejs.org/)
+- Conocimiento de git y comandos de terminal comunes
 
 ## Dependencias de desarrollo
 
--   TypeScript (opcional)
--   Gestor de paquetes NPM o Yarn
+- TypeScript (opcional)
+- Gestor de paquetes NPM o Yarn
 
 ## Pasos
 
@@ -202,7 +202,7 @@ Para subir esta aplicación, es posible que necesites agregar AR y financiar tu 
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```
@@ -269,7 +269,7 @@ Si tu aplicación pesa más de 120 KB o recibes el error `Not enough funds to se
 
 Un ejemplo completamente funcional en JavaScript o TypeScript se puede encontrar en esta ubicación.
 
--   Repositorio: [https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
+- Repositorio: [https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
 
 ## Resumen
 

--- a/docs/src/getting-started/quick-starts/hw-cli.md
+++ b/docs/src/getting-started/quick-starts/hw-cli.md
@@ -4,7 +4,7 @@ This guide walks you through the most simple way to get data on to the permaweb 
 
 ## Requirements
 
--   [NodeJS](https://nodejs.org) LTS or greater
+- [NodeJS](https://nodejs.org) LTS or greater
 
 ## Description
 
@@ -30,8 +30,8 @@ node -e "require('arweave').init({}).wallets.generate().then(JSON.stringify).the
 echo "<h1>Hello Permaweb</h1>" > index.html
 ```
 
-## Upload using Irys (Previously Bundlr)
+## Upload using Irys
 
 ```sh
-npx irys upload index.html -t arweave -h https://node2.irys.xyz -w ./wallet.json
+npx irys upload index.html -t arweave -n mainnet -w ./wallet.json
 ```

--- a/docs/src/getting-started/quick-starts/hw-code.md
+++ b/docs/src/getting-started/quick-starts/hw-code.md
@@ -48,19 +48,19 @@ Paste the code from the following code blocks into their files:
 ```html
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="style.css" />
-    <script src="index.js"></script>
-    <title>Cookbook Hello World!</title>
-  </head>
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="stylesheet" type="text/css" href="style.css" />
+		<script src="index.js"></script>
+		<title>Cookbook Hello World!</title>
+	</head>
 
-  <body>
-    <button onclick="changeColor()" class="button">Click Me!</button>
-    <h1 id="main">Hello World!</h1>
-  </body>
+	<body>
+		<button onclick="changeColor()" class="button">Click Me!</button>
+		<h1 id="main">Hello World!</h1>
+	</body>
 </html>
 ```
 
@@ -74,8 +74,8 @@ Paste the code from the following code blocks into their files:
 
 ```css
 .button {
-  padding: "10px";
-  background-color: #4caf50;
+	padding: "10px";
+	background-color: #4caf50;
 }
 ```
 
@@ -89,10 +89,8 @@ Paste the code from the following code blocks into their files:
 
 ```javascript
 function changeColor() {
-  const header = document.getElementById("main");
-  header.style.color === ""
-    ? (header.style.color = "red")
-    : (header.style.color = "");
+	const header = document.getElementById("main");
+	header.style.color === "" ? (header.style.color = "red") : (header.style.color = "");
 }
 ```
 
@@ -102,12 +100,12 @@ function changeColor() {
 
 Now that there is a static site to deploy, it can be checked to ensure it all functions properly by typing `open src/index.html` in your console/terminal. If everything is working as expected it is time to deploy to Arweave!
 
-## Upload using Irys (Previously Bundlr)
+## Upload using Irys
 
 The command below deploys the `src` directory whilst also indicating the `index.html` file as an index for the manifests (relative to the path provided to `upload-dir` flag).
 
 ```sh
-irys upload-dir src -h https://node2.irys.xyz --index-file index.html -t arweave -w ./wallet.json
+irys upload-dir src -n mainnet --index-file index.html -t arweave -w ./wallet.json
 ```
 
 ## Congrats!!

--- a/docs/src/getting-started/quick-starts/hw-nodejs.md
+++ b/docs/src/getting-started/quick-starts/hw-nodejs.md
@@ -6,7 +6,7 @@ With Arweave 2.6 only allowing 1000 items per block, directly posting to the gat
 
 ## Requirements
 
--   [NodeJS](https://nodejs.org) LTS or greater
+- [NodeJS](https://nodejs.org) LTS or greater
 
 ## Description
 
@@ -26,7 +26,7 @@ npm install arweave @irys/sdk
 node -e "require('arweave').init({}).wallets.generate().then(JSON.stringify).then(console.log.bind(console))" > wallet.json
 ```
 
-## Upload using Irys (Previously Bundlr)
+## Upload using Irys
 
 Uploads of less than 100 KiB are currently free on Irys' Node 2.
 
@@ -35,11 +35,10 @@ import Irys from "@irys/sdk";
 import fs from "fs";
 
 const jwk = JSON.parse(fs.readFileSync("wallet.json").toString());
-const url = "https://node2.irys.xyz";
 const token = "arweave";
 
 const irys = new Irys({
-	url, // URL of the node you want to connect to
+	network : "mainnet", // Irys network "mainnet" || "devnet"
 	token, // Token used for payment and signing
 	jwk, // Arweave wallet
 });
@@ -87,6 +86,6 @@ console.log(`https://arweave.net/${tx.id}`);
 
 ## Resources
 
--   [Irys SDK](https://github.com/irys-xyz/js-sdk)
--   [Arweave JS SDK](https://github.com/ArweaveTeam/arweave-js)
--   [Irys Docs: Free Uploads](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)
+- [Irys SDK](https://github.com/irys-xyz/js-sdk)
+- [Arweave JS SDK](https://github.com/ArweaveTeam/arweave-js)
+- [Irys Docs: Free Uploads](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)

--- a/docs/src/guides/atomic-tokens/intro.md
+++ b/docs/src/guides/atomic-tokens/intro.md
@@ -20,7 +20,10 @@ async function main() {
   const wallet = JSON.parse(await import('fs')
     .then(fs => fs.readFileSync('./wallet.json', 'utf-8')))
 
-  const irys = new Irys({ 'https://node2.irys.xyz', 'arweave', wallet })
+  const irys = new Irys({
+			network: 'mainnet', // Irys network 'mainnet' || 'devnet'
+		 'arweave',
+		 wallet })
   const warp = WarpFactory.forMainnet()
 
   const data = `<h1>Hello Permaweb!</h1>`

--- a/docs/src/guides/deploying-manifests/irys.md
+++ b/docs/src/guides/deploying-manifests/irys.md
@@ -1,4 +1,4 @@
-### Irys (Previously Bundlr)
+### Irys
 
 When uploading a folder or group of files from the Irys [CLI](http://docs.irys.xyz/developer-docs/cli), [server](http://docs.irys.xyz/developer-docs/irys-sdk) or from the [browser](http://docs.irys.xyz/developer-docs/irys-sdk/irys-in-the-browser), a manifest is automatically generated for the files.
 

--- a/docs/src/guides/deployment/arkb.md
+++ b/docs/src/guides/deployment/arkb.md
@@ -54,9 +54,9 @@ arkb deploy [folder] --wallet [path to wallet]
 
 #### Bundled Deployment
 
-To deploy using Bundlr you will need to <a href="#fund-bundlr">fund a Bundlr node</a>.
+To deploy using Irys you will need to <a href="#fund-irys">fund an Irys node</a>.
 
-Bundlr node2 allows free transactions under 100kb.
+Bundlr allows free transactions under 100kb.
 
 You can add custom identifiable tags to the deployment using `tag-name/tag-value` syntax.
 
@@ -69,13 +69,13 @@ arkb deploy [folder] --use-bundler [bundlr node] --wallet [path to wallet] --tag
 
 ## Other Commands
 
-#### Fund Bundlr
+#### Fund Irys
 
 ```console
 arkb fund-bundler [amount] --use-bundler [bundlr node]
 ```
 
-<sub style="float:right">\* Funding a Bundlr instance can take up to 30 minutes to process</sub>
+<sub style="float:right">\* Funding an Irys instance can take up to 30 minutes to process</sub>
 
 #### Saving Keyfile
 

--- a/docs/src/guides/deployment/github-action.md
+++ b/docs/src/guides/deployment/github-action.md
@@ -35,11 +35,11 @@ import Arweave from "arweave";
 
 const ANT = "[YOUR ANT CONTRACT]";
 const DEPLOY_FOLDER = "./dist";
-const IRYS_NODE = "https://node2.irys.xyz";
+const IRYS_NETWORK = "mainnet"; // Irys network "mainnet" || "devnet"
 
 const jwk = JSON.parse(Buffer.from(process.env.PERMAWEB_KEY, "base64").toString("utf-8"));
 const arweave = Arweave.init({ host: "arweave.net", port: 443, protocol: "https" });
-const irys = new Irys({ url: IRYS_NODE, token: "arweave", key: jwk });
+const irys = new Irys({ network: IRYS_NETWORK, token: "arweave", key: jwk });
 const warp = WarpFactory.custom(arweave, defaultCacheOptions, "mainnet").useArweaveGateway().build();
 
 const contract = warp.contract(ANT).connect(jwk);
@@ -82,22 +82,22 @@ Create a `deploy.yml` file in the `.github/workflows` folder, this file instruct
 name: publish
 
 on:
-    push:
-        branches:
-            - "main"
+  push:
+    branches:
+      - "main"
 
 jobs:
-    publish:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 18.x
-            - run: yarn
-            - run: yarn deploy
-              env:
-                  KEY: ${{ secrets.PERMAWEB_KEY }}
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - run: yarn
+      - run: yarn deploy
+        env:
+          KEY: ${{ secrets.PERMAWEB_KEY }}
 ```
 
 ## Summary
@@ -111,7 +111,7 @@ base64 -i wallet.json | pbcopy
 In order for this deployment to work, you will need to fund this wallets Irys account, make sure there is some $AR in the wallet you will be using, not much, maybe .5 AR, then use the Irys cli to fund.
 
 ```console
-irys fund 250000000000 -h https://node2.irys.xyz -w wallet.json -t arweave
+irys fund 250000000000 -n mainnet -w wallet.json -t arweave
 ```
 
 ::: warning

--- a/docs/src/guides/deployment/irys-cli.md
+++ b/docs/src/guides/deployment/irys-cli.md
@@ -1,4 +1,4 @@
-# Irys CLI (Previously Bundlr)
+# Irys CLI
 
 ## Requirements
 

--- a/docs/src/guides/posting-transactions/irys.md
+++ b/docs/src/guides/posting-transactions/irys.md
@@ -1,4 +1,4 @@
-# Posting Transactions using Irys (Previously Bundlr)
+# Posting Transactions using Irys
 
 Posting transactions to irys.xyz can be accomplished using the `irys.xyz/sdk` JavaScript package. Bundling services enable guaranteed confirmation of posted transactions as well as supporting many thousands of transactions per block though the use of transaction bundles.
 
@@ -31,13 +31,12 @@ A difference between posting Layer 1 and bundled Layer 2 transactions is that wh
 import Irys from "@irys/sdk";
 import fs from "fs";
 
-const url = "https://node1.irys.xyz";
 const token = "arweave";
 // load the JWK wallet key file from disk
 let key = JSON.parse(fs.readFileSync("walletFile.txt").toString());
 
 const irys = new Irys({
-	url, // URL of the node you want to connect to
+	network: "mainnet", // Irys network, "mainnet" || "devnet"
 	token, // Token used for payment and signing
 	key, // Arweave wallet
 });
@@ -76,8 +75,8 @@ try {
 
 ## Resources
 
--   For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/post-transactions.md) section of the cookbook.
+- For an overview of all the ways you can post transactions, see the [Posting Transactions](../../concepts/post-transactions.md) section of the cookbook.
 
--   The full Irys client docs can be found on the [irys.xyz website](http://docs.irys.xyz/developer-docs/irys-sdk)
+- The full Irys client docs can be found on the [irys.xyz website](http://docs.irys.xyz/developer-docs/irys-sdk)
 
--   A tutorial for [uploading NFT assets](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts) using Irys.
+- A tutorial for [uploading NFT assets](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts) using Irys.

--- a/docs/src/guides/smartweave/warp/deploying-contracts.md
+++ b/docs/src/guides/smartweave/warp/deploying-contracts.md
@@ -35,10 +35,10 @@ function deploy(initState, src) {
 
 There are 4 ways you can deploy a SmartWeaveContract via the Warp SDK, these options handle different use cases that a developer may encounter.
 
--   Need to deploy the contract with the source at the same time
--   Need to deploy a contract where the source is already on the permaweb
--   Need to deploy a contract through the sequencer and point it to some data using a path manifest
--   Need to deploy a contract via Irys and register that contract on the sequencer
+- Need to deploy the contract with the source at the same time
+- Need to deploy a contract where the source is already on the permaweb
+- Need to deploy a contract through the sequencer and point it to some data using a path manifest
+- Need to deploy a contract via Irys and register that contract on the sequencer
 
 ::: tip
 For more information about Warp deployments check out the github Readme for the project. [https://github.com/warp-contracts/warp#deployment](https://github.com/warp-contracts/warp#deployment).
@@ -68,11 +68,11 @@ const { contractTxId, srcTxId } = await warp.deploy({
 });
 ```
 
--   wallet - should be Arweave keyfile (wallet.json) parsed as a JSON object implementing the [JWK Interface](https://rfc-editor.org/rfc/rfc7517) or the string 'use_wallet'
--   initState - is a stringified JSON object
--   data - is optional if you want to write data as part of your deployment
--   src - is the string or Uint8Array value of the source code for the contract
--   tags - is an array of name/value objects `{name: string, value: string}[]`, [Learn more about tags](../../../concepts/tags.md)
+- wallet - should be Arweave keyfile (wallet.json) parsed as a JSON object implementing the [JWK Interface](https://rfc-editor.org/rfc/rfc7517) or the string 'use_wallet'
+- initState - is a stringified JSON object
+- data - is optional if you want to write data as part of your deployment
+- src - is the string or Uint8Array value of the source code for the contract
+- tags - is an array of name/value objects `{name: string, value: string}[]`, [Learn more about tags](../../../concepts/tags.md)
 
 **deployFromSourceTx**
 
@@ -118,7 +118,10 @@ Uses Warp Gateway Sequencer's endpoint to index a contract that has been uploade
 ```ts
 import Irys from '@irys/sdk'
 
-const irys = new Irys({ 'https://node2.irys.xyz', 'arweave', wallet })
+const irys = new Irys({
+	network: 'mainnet', // Irys network, "mainnet" || "devnet"
+	'arweave',
+	wallet })
 const { id } = await irys.upload('Some Awesome Atomic Asset',  {
   tags: [{'Content-Type': 'text/plain' }]
 })

--- a/docs/src/id/getting-started/quick-starts/hw-cli.md
+++ b/docs/src/id/getting-started/quick-starts/hw-cli.md
@@ -8,7 +8,7 @@ Panduan ini akan membantu Anda untuk melakukan hal yang paling sederhana, yaitu 
 
 ## Persyaratan
 
--   [NodeJS](https://nodejs.org) LTS atau yang lebih baru
+- [NodeJS](https://nodejs.org) LTS atau yang lebih baru
 
 ## Deskripsi
 
@@ -37,5 +37,5 @@ echo "<h1>Halo Permaweb</h1>" > index.html
 ## Mengunggah menggunakan Irys
 
 ```sh
-irys upload index.html -c arweave -h https://node2.irys.xyz -w ./wallet.json
+irys upload index.html -c arweave -n mainnet -w ./wallet.json
 ```

--- a/docs/src/id/getting-started/quick-starts/hw-code.md
+++ b/docs/src/id/getting-started/quick-starts/hw-code.md
@@ -8,9 +8,9 @@ Panduan ini akan membimbing Anda untuk dengan cepat mendapatkan halaman web stat
 
 ## Persyaratan
 
--   [NodeJS](https://nodejs.org) LTS atau yang lebih tinggi
--   Pengetahuan dasar tentang HTML, CSS, dan JavaScript
--   Sebuah text editor (seperti VS Code, Sublime, atau sejenisnya)
+- [NodeJS](https://nodejs.org) LTS atau yang lebih tinggi
+- Pengetahuan dasar tentang HTML, CSS, dan JavaScript
+- Sebuah text editor (seperti VS Code, Sublime, atau sejenisnya)
 
 ## Deskripsi
 
@@ -105,7 +105,7 @@ Sekarang bahwa ada situs statis yang akan dideploy, Anda dapat memeriksanya untu
 Perintah di bawah ini mendeploy direktori `src` dan menunjukkan file `index.html` sebagai indeks untuk manifest (relatif terhadap path yang diberikan ke flag `upload-dir`).
 
 ```sh
-irys upload-dir src -h https://node2.irys.xyz --index-file index.html -c arweave -w ./wallet.json
+irys upload-dir src -n mainnet --index-file index.html -c arweave -w ./wallet.json
 ```
 
 ## Selamat!!

--- a/docs/src/id/getting-started/quick-starts/hw-nodejs.md
+++ b/docs/src/id/getting-started/quick-starts/hw-nodejs.md
@@ -10,7 +10,7 @@ Dengan Arweave 2.6 hanya memungkinkan 1000 item per blok, pengunggahan langsung 
 
 ## Persyaratan
 
--   [NodeJS](https://nodejs.org) LTS atau yang lebih baru
+- [NodeJS](https://nodejs.org) LTS atau yang lebih baru
 
 ## Deskripsi
 
@@ -37,11 +37,10 @@ import Irys from "@irys/sdk";
 import fs from "fs";
 
 const jwk = JSON.parse(fs.readFileSync("wallet.json").toString());
-const url = "https://node2.irys.xyz";
 const token = "arweave";
 
 const irys = new Irys({
-	url, // URL of the node you want to connect to
+	network: "mainnet", // Irys network, "mainnet" || "devnet"
 	token, // Token used for payment and signing
 	jwk, // Arweave wallet
 });
@@ -89,6 +88,6 @@ console.log(`https://arweave.net/${tx.id}`);
 
 ## Sumber Daya
 
--   [SDK Irys](https://github.com/irys-xyz/js-sdk)
--   [Arweave JS SDK](https://github.com/ArweaveTeam/arweave-js)
--   [Dokumentasi Irys: Unggahan Gratis](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)
+- [SDK Irys](https://github.com/irys-xyz/js-sdk)
+- [Arweave JS SDK](https://github.com/ArweaveTeam/arweave-js)
+- [Dokumentasi Irys: Unggahan Gratis](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)

--- a/docs/src/id/guides/atomic-tokens/intro.md
+++ b/docs/src/id/guides/atomic-tokens/intro.md
@@ -24,7 +24,10 @@ async function main() {
   const wallet = JSON.parse(await import('fs')
     .then(fs => fs.readFileSync('./wallet.json', 'utf-8')))
 
-  const irys = new Irys({ 'https://node2.irys.xyz', 'arweave', wallet })
+  const irys = new Irys({
+		network: 'mainnet', // Irys network, "mainnet" || "devnet"
+		'arweave',
+		wallet })
   const warp = WarpFactory.forMainnet()
 
   const data = `<h1>Halo Permaweb!</h1>`

--- a/docs/src/id/guides/deployment/github-action.md
+++ b/docs/src/id/guides/deployment/github-action.md
@@ -39,12 +39,12 @@ import Arweave from "arweave";
 
 const ANT = "[ANT CONTRACT ANDA]";
 const DEPLOY_FOLDER = "./dist";
-const IRYS_NODE = "https://node2.irys.xyz";
+const IRYS_NETWORK = "mainnet"; // "mainnet" || "devnet"
 
 const arweave = Arweave.init({ host: "arweave.net", port: 443, protocol: "https" });
 const jwk = JSON.parse(Buffer.from(process.env.PERMAWEB_KEY, "base64").toString("utf-8"));
 
-const irys = new Irys({ IRYS_NODE, "arweave", jwk });
+const irys = new Irys({ network: IRYS_NETWORK, token: "arweave", key: jwk });
 const warp = WarpFactory.custom(arweave, defaultCacheOptions, "mainnet").useArweaveGateway().build();
 
 const contract = warp.contract(ANT).connect(jwk);
@@ -87,22 +87,22 @@ Buat file `deploy.yml` di folder `.github/workflows`, file ini menginstruksikan 
 name: publish
 
 on:
-    push:
-        branches:
-            - "main"
+  push:
+    branches:
+      - "main"
 
 jobs:
-    publish:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 18.x
-            - run: yarn
-            - run: yarn deploy
-              env:
-                  KEY: ${{ secrets.PERMAWEB_KEY }}
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - run: yarn
+      - run: yarn deploy
+        env:
+          KEY: ${{ secrets.PERMAWEB_KEY }}
 ```
 
 ## Ringkasan
@@ -116,7 +116,7 @@ base64 -i wallet.json | pbcopy
 Agar penyebaran ini berfungsi, Anda perlu mendanai akun Irys dompet ini, pastikan ada beberapa $AR di dompet yang akan Anda gunakan, tidak banyak, mungkin .5 AR, kemudian gunakan Irys cli untuk mendanai.
 
 ```console
-irys fund 250000000000 -h https://node2.irys.xyz -w wallet.json -t arweave
+irys fund 250000000000 -n mainnet -w wallet.json -t arweave
 ```
 
 ::: warning

--- a/docs/src/id/guides/deployment/irys-cli.md
+++ b/docs/src/id/guides/deployment/irys-cli.md
@@ -2,7 +2,7 @@
 locale: id
 ---
 
-# Irys CLI (Previously Bundlr)
+# Irys CLI
 
 ## Prasyarat
 

--- a/docs/src/id/guides/posting-transactions/irys.md
+++ b/docs/src/id/guides/posting-transactions/irys.md
@@ -39,7 +39,10 @@ import fs from "fs";
 let key = JSON.parse(fs.readFileSync("walletFile.txt").toString());
 
 // inisialisasi SDK Irys
-const irys = new Irys({ "http://node1.irys.xyz", "arweave", key });
+const irys = new Irys({
+		network: "mainnet", // Irys network, "mainnet" || "devnet"
+		"arweave",
+		key });
 ```
 
 ## Mengirimkan Transaksi yang Dibundel
@@ -63,8 +66,8 @@ await tx.upload();
 
 ## Sumber Daya
 
--   Untuk gambaran semua cara Anda dapat memposting transaksi, lihat bagian [Posting Transactions](../../concepts/post-transactions.md) dari buku masak.
+- Untuk gambaran semua cara Anda dapat memposting transaksi, lihat bagian [Posting Transactions](../../concepts/post-transactions.md) dari buku masak.
 
--   Dokumentasi lengkap Irys client dapat ditemukan di [situs web irys.xyz](https://docs.irys.xyz)
+- Dokumentasi lengkap Irys client dapat ditemukan di [situs web irys.xyz](https://docs.irys.xyz)
 
--   Tutorial dan lokakarya untuk [mengunggah koleksi NFT](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts) menggunakan Irys.
+- Tutorial dan lokakarya untuk [mengunggah koleksi NFT](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts) menggunakan Irys.

--- a/docs/src/id/guides/smartweave/warp/deploying-contracts.md
+++ b/docs/src/id/guides/smartweave/warp/deploying-contracts.md
@@ -39,10 +39,10 @@ async function deploy(initState, src) {
 
 Ada 4 cara Anda dapat menyelenggarakan Kontrak SmartWeave menggunakan SDK Warp, pilihan-pilihan ini menangani berbagai kasus penggunaan yang mungkin dihadapi oleh pengembang.
 
--   Perlu menyelenggarakan kontrak dengan sumber kode pada saat yang sama.
--   Perlu menyelenggarakan kontrak di mana sumber kode sudah ada di Permaweb.
--   Perlu menyelenggarakan kontrak melalui pengurutan (sequencer) dan mengarahkannya ke beberapa data menggunakan manifes jalur (path manifest).
--   Perlu menyelenggarakan kontrak melalui Irys dan mendaftarkan kontrak tersebut pada pengurutan (sequencer).
+- Perlu menyelenggarakan kontrak dengan sumber kode pada saat yang sama.
+- Perlu menyelenggarakan kontrak di mana sumber kode sudah ada di Permaweb.
+- Perlu menyelenggarakan kontrak melalui pengurutan (sequencer) dan mengarahkannya ke beberapa data menggunakan manifes jalur (path manifest).
+- Perlu menyelenggarakan kontrak melalui Irys dan mendaftarkan kontrak tersebut pada pengurutan (sequencer).
 
 ::: tip
 Untuk informasi lebih lanjut tentang penyelenggaraan Warp, lihat Readme di GitHub untuk proyek ini. [https://github.com/warp-contracts/warp#deployment](https://github.com/warp-contracts/warp#deployment).
@@ -72,11 +72,11 @@ const { contractTxId, srcTxId } = await warp.deploy({
 });
 ```
 
--   wallet - seharusnya berupa keyfile Arweave (wallet.json) yang diurai sebagai objek JSON yang mengimplementasikan [JWK Interface](https://rfc-editor.org/rfc/rfc7517) atau string 'use_wallet'.
--   initState - adalah objek JSON yang telah diubah menjadi string.
--   data - opsional jika Anda ingin menulis data sebagai bagian dari penyelenggaraan Anda.
--   src - adalah nilai string atau Uint8Array dari kode sumber kontrak.
--   tags - adalah array dari objek nama/nilai `{name: string, value: string}[]`, [Pelajari lebih lanjut tentang tags](../../../concepts/tags.md).
+- wallet - seharusnya berupa keyfile Arweave (wallet.json) yang diurai sebagai objek JSON yang mengimplementasikan [JWK Interface](https://rfc-editor.org/rfc/rfc7517) atau string 'use_wallet'.
+- initState - adalah objek JSON yang telah diubah menjadi string.
+- data - opsional jika Anda ingin menulis data sebagai bagian dari penyelenggaraan Anda.
+- src - adalah nilai string atau Uint8Array dari kode sumber kontrak.
+- tags - adalah array dari objek nama/nilai `{name: string, value: string}[]`, [Pelajari lebih lanjut tentang tags](../../../concepts/tags.md).
 
 **deployFromSourceTx**
 
@@ -122,7 +122,10 @@ Menggunakan endpoint Sequencer Warp Gateway untuk mengindekskan kontrak yang tel
 ```ts
 import Irys from '@irys/sdk'
 
-const irys = new Irys({ 'https://node2.irys.xyz', 'arweave', wallet })
+const irys = new Irys({
+		network: 'mainnet', // Irys network, "mainnet" || "devnet"
+		'arweave',
+		wallet })
 const { id } = await irys.upload('Some Awesome Atomic Asset',  {
   tags: [{'Content-Type': 'text/plain' }]
 })

--- a/docs/src/id/kits/react/create-react-app.md
+++ b/docs/src/id/kits/react/create-react-app.md
@@ -10,15 +10,15 @@ Panduan ini akan membimbing Anda melalui langkah demi langkah untuk mengonfigura
 
 ## Prasyarat
 
--   Pengetahuan Dasar Typescript (Tidak Wajib) - [Pelajari Typescript](https://www.typescriptlang.org/docs/)
--   NodeJS v16.15.0 atau lebih baru - [Unduh NodeJS](https://nodejs.org/en/download/)
--   Pengetahuan tentang ReactJS - [Pelajari ReactJS](https://reactjs.org/)
--   Mengenal git dan perintah terminal umum
+- Pengetahuan Dasar Typescript (Tidak Wajib) - [Pelajari Typescript](https://www.typescriptlang.org/docs/)
+- NodeJS v16.15.0 atau lebih baru - [Unduh NodeJS](https://nodejs.org/en/download/)
+- Pengetahuan tentang ReactJS - [Pelajari ReactJS](https://reactjs.org/)
+- Mengenal git dan perintah terminal umum
 
 ## Dependensi Pengembangan
 
--   TypeScript
--   Manajer Paket NPM atau Yarn
+- TypeScript
+- Manajer Paket NPM atau Yarn
 
 ## Langkah-Langkah
 
@@ -239,7 +239,7 @@ Anda harus menambahkan AR ke dompet ini dan mendanai dompet Irys Anda agar dapat
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./build -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./build -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
   ...
 }
@@ -299,14 +299,14 @@ Jika Anda menerima kesalahan ini `Not enough funds to send data`, Anda harus men
   <CodeGroupItem title="NPM">
   
 ```console:no-line-numbers
-irys fund 1479016 -h https://node1.irys.xyz -w wallet.json -c arweave
+irys fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>
   <CodeGroupItem title="YARN">
   
 ```console:no-line-numbers
-iryz fund 1479016 -h https://node1.iryz.xyz -w wallet.json -c arweave
+iryz fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>

--- a/docs/src/id/kits/react/vite.md
+++ b/docs/src/id/kits/react/vite.md
@@ -10,15 +10,15 @@ Panduan ini akan membimbing Anda langkah demi langkah untuk mengonfigurasi lingk
 
 ## Persyaratan
 
--   Pengetahuan Dasar TypeScript (Tidak Wajib) - [Pelajari TypeScript](https://www.typescriptlang.org/docs/)
--   NodeJS v16.15.0 atau lebih baru - [Unduh NodeJS](https://nodejs.org/en/download/)
--   Pengetahuan tentang ReactJS - [Pelajari ReactJS](https://reactjs.org/)
--   Mengetahui git dan perintah terminal umum
+- Pengetahuan Dasar TypeScript (Tidak Wajib) - [Pelajari TypeScript](https://www.typescriptlang.org/docs/)
+- NodeJS v16.15.0 atau lebih baru - [Unduh NodeJS](https://nodejs.org/en/download/)
+- Pengetahuan tentang ReactJS - [Pelajari ReactJS](https://reactjs.org/)
+- Mengetahui git dan perintah terminal umum
 
 ## Dependensi Pengembangan
 
--   TypeScript
--   NPM atau Yarn Package Manager
+- TypeScript
+- NPM atau Yarn Package Manager
 
 ## Langkah-langkah
 
@@ -256,7 +256,7 @@ Anda perlu menambahkan AR ke wallet ini dan mendanai wallet Irys Anda agar dapat
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
   ...
 }

--- a/docs/src/id/kits/svelte/minimal.md
+++ b/docs/src/id/kits/svelte/minimal.md
@@ -10,17 +10,17 @@ Panduan ini akan membimbing Anda langkah demi langkah dalam mengkonfigurasi ling
 
 ## Persyaratan
 
--   Mengenal TypeScript
--   NodeJS v18 atau yang lebih tinggi
--   Mengenal Svelte - [https://svelte.dev](https://svelte.dev)
--   Mengenal git dan perintah terminal umum
+- Mengenal TypeScript
+- NodeJS v18 atau yang lebih tinggi
+- Mengenal Svelte - [https://svelte.dev](https://svelte.dev)
+- Mengenal git dan perintah terminal umum
 
 ## Ketergantungan Pengembangan
 
--   TypeScript
--   esbuild
--   w3
--   yarn `npm i -g yarn`
+- TypeScript
+- esbuild
+- w3
+- yarn `npm i -g yarn`
 
 ## Langkah-langkah
 
@@ -170,7 +170,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/id/kits/svelte/vite.md
+++ b/docs/src/id/kits/svelte/vite.md
@@ -213,7 +213,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "yarn build && irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "yarn build && irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/id/kits/vue/create-vue.md
+++ b/docs/src/id/kits/vue/create-vue.md
@@ -10,15 +10,15 @@ Panduan ini akan memberikan instruksi langkah demi langkah untuk mengonfigurasi 
 
 ## Persyaratan
 
--   Pengetahuan Dasar tentang TypeScript (Tidak Wajib) - [Pelajari TypeScript](https://www.typescriptlang.org/docs/)
--   NodeJS v16.15.0 atau yang lebih baru - [Unduh NodeJS](https://nodejs.org/en/download/)
--   Pengetahuan tentang Vue.js (lebih baik lagi Vue 3) - [Pelajari Vue.js](https://vuejs.org/)
--   Mengetahui git dan perintah terminal umum
+- Pengetahuan Dasar tentang TypeScript (Tidak Wajib) - [Pelajari TypeScript](https://www.typescriptlang.org/docs/)
+- NodeJS v16.15.0 atau yang lebih baru - [Unduh NodeJS](https://nodejs.org/en/download/)
+- Pengetahuan tentang Vue.js (lebih baik lagi Vue 3) - [Pelajari Vue.js](https://vuejs.org/)
+- Mengetahui git dan perintah terminal umum
 
 ## Dependensi Pengembangan
 
--   TypeScript (Opsional)
--   Manajer Paket NPM atau Yarn
+- TypeScript (Opsional)
+- Manajer Paket NPM atau Yarn
 
 ## Langkah-langkah
 
@@ -204,7 +204,7 @@ Untuk mengunggah aplikasi ini, Anda mungkin perlu menambahkan AR dan mengisi wal
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```
@@ -271,7 +271,7 @@ Jika aplikasi Anda lebih dari 120 kb atau Anda menerima pesan kesalahan `Not eno
 
 Contoh yang sepenuhnya fungsional dalam JavaScript atau TypeScript dapat ditemukan di lokasi ini.
 
--   Repositori: [https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
+- Repositori: [https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
 
 ## Ringkasan
 

--- a/docs/src/kits/react/create-react-app.md
+++ b/docs/src/kits/react/create-react-app.md
@@ -4,15 +4,15 @@ This guide will walk you through in a step by step flow to configure your develo
 
 ## Prerequisites
 
--   Basic Typescript Knowledge (Not Mandatory) - [https://www.typescriptlang.org/docs/](Learn Typescript)
--   NodeJS v16.15.0 or greater - [https://nodejs.org/en/download/](Download NodeJS)
--   Knowledge of ReactJS - [https://reactjs.org/](Learn ReactJS)
--   Know git and common terminal commands
+- Basic Typescript Knowledge (Not Mandatory) - [https://www.typescriptlang.org/docs/](Learn Typescript)
+- NodeJS v16.15.0 or greater - [https://nodejs.org/en/download/](Download NodeJS)
+- Knowledge of ReactJS - [https://reactjs.org/](Learn ReactJS)
+- Know git and common terminal commands
 
 ## Development Dependencies
 
--   TypeScript
--   NPM or Yarn Package Manager
+- TypeScript
+- NPM or Yarn Package Manager
 
 ## Steps
 
@@ -234,7 +234,7 @@ You will need to add AR to this wallet and fund your Irys wallet to be able to u
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./build -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./build -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
   ...
 }
@@ -294,14 +294,14 @@ If you receive this error `Not enough funds to send data`, you have to fund some
   <CodeGroupItem title="NPM">
   
 ```console:no-line-numbers
-irys fund 1479016 -h https://node1.irys.xyz -w wallet.json -c arweave
+irys fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>
   <CodeGroupItem title="YARN">
   
 ```console:no-line-numbers
-irys fund 1479016 -h https://node1.irys.xyz -w wallet.json -c arweave
+irys fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>

--- a/docs/src/kits/react/vite.md
+++ b/docs/src/kits/react/vite.md
@@ -4,15 +4,15 @@ This guide will walk you through in a step by step flow to configure your develo
 
 ## Prerequisites
 
--   Basic Typescript Knowledge (Not Mandatory) - [https://www.typescriptlang.org/docs/](Learn Typescript)
--   NodeJS v16.15.0 or greater - [https://nodejs.org/en/download/](Download NodeJS)
--   Knowledge of ReactJS - [https://reactjs.org/](Learn ReactJS)
--   Know git and common terminal commands
+- Basic Typescript Knowledge (Not Mandatory) - [https://www.typescriptlang.org/docs/](Learn Typescript)
+- NodeJS v16.15.0 or greater - [https://nodejs.org/en/download/](Download NodeJS)
+- Knowledge of ReactJS - [https://reactjs.org/](Learn ReactJS)
+- Know git and common terminal commands
 
 ## Development Dependencies
 
--   TypeScript
--   NPM or Yarn Package Manager
+- TypeScript
+- NPM or Yarn Package Manager
 
 ## Steps
 
@@ -226,14 +226,14 @@ Make sure you add the `base` property to the vite config object and set it to an
 vite.config.ts
 
 ```ts
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '',
-  plugins: [react()],
-})
+	base: "",
+	plugins: [react()],
+});
 ```
 
 ### Setup Irys
@@ -268,7 +268,7 @@ You will need to add AR to this wallet and fund your Irys wallet to be able to u
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./dist -h https://node2.irys.xyz --wallet ./wallet.json -t arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./dist -n mainnet --wallet ./wallet.json -t arweave --index-file index.html --no-confirmation"
   }
   ...
 }
@@ -329,17 +329,15 @@ How do I fund my irys account?
 Check balance
 
 ```console:no-line-numbers
-irys balance [Address] -h https://node2.irys.xyz -t arweave
+irys balance [Address] -n mainnet -t arweave
 ```
 
 Fund Irys
 
 ```console:no-line-numbers
-irys fund 20000000000 -t arweave -h https://node2.irys.xyz -w ./wallet.json
+irys fund 20000000000 -t arweave -n mainnet -w ./wallet.json
 ```
 
 ::: tip INFO
 It will take about 20 to 30 minutes for the funds to be deposited into your irys account.
 :::
-
-

--- a/docs/src/kits/svelte/minimal.md
+++ b/docs/src/kits/svelte/minimal.md
@@ -4,17 +4,17 @@ This guide will walk you through in a step by step flow to configure your develo
 
 ## Prerequisites
 
--   Know typescript
--   NodeJS v18 or greater
--   Know Svelte - [https://svelte.dev](https://svelte.dev)
--   Know git and common terminal commands
+- Know typescript
+- NodeJS v18 or greater
+- Know Svelte - [https://svelte.dev](https://svelte.dev)
+- Know git and common terminal commands
 
 ## Development Dependencies
 
--   TypeScript
--   esbuild
--   w3
--   yarn `npm i -g yarn`
+- TypeScript
+- esbuild
+- w3
+- yarn `npm i -g yarn`
 
 ## Steps
 
@@ -164,7 +164,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/kits/svelte/vite.md
+++ b/docs/src/kits/svelte/vite.md
@@ -207,7 +207,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "yarn build && irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "yarn build && irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/kits/vue/create-vue.md
+++ b/docs/src/kits/vue/create-vue.md
@@ -4,15 +4,15 @@ This guide will provide step-by-step instructions to configure your development 
 
 ## Prerequisites
 
--   Basic Typescript Knowledge (Not Mandatory) - [Learn Typescript](https://www.typescriptlang.org/docs/)
--   NodeJS v16.15.0 or greater - [Download NodeJS](https://nodejs.org/en/download/)
--   Knowledge of Vue.js (preferably Vue 3) - [Learn Vue.js](https://vuejs.org/)
--   Know git and common terminal commands
+- Basic Typescript Knowledge (Not Mandatory) - [Learn Typescript](https://www.typescriptlang.org/docs/)
+- NodeJS v16.15.0 or greater - [Download NodeJS](https://nodejs.org/en/download/)
+- Knowledge of Vue.js (preferably Vue 3) - [Learn Vue.js](https://vuejs.org/)
+- Know git and common terminal commands
 
 ## Development Dependencies
 
--   TypeScript (Optional)
--   NPM or Yarn Package Manager
+- TypeScript (Optional)
+- NPM or Yarn Package Manager
 
 ## Steps
 
@@ -198,7 +198,7 @@ To upload this app, you may need to add AR and fund your Irys wallet. Visit [htt
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```
@@ -265,7 +265,7 @@ if your application is greater than 120 kb or you receive the error `Not enough 
 
 A fully functional example in JavaScript or TypeScript can be found at this location.
 
--   Repository: [https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
+- Repository: [https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
 
 ## Summary
 

--- a/docs/src/references/irysQueryPackage.md
+++ b/docs/src/references/irysQueryPackage.md
@@ -29,33 +29,37 @@ Import with:
 import Query from "@irys/query";
 ```
 
-## Endpoints
+## Query location (mainnet, devnet, arweave)
 
-The `Query` class links to a GraphQL endpoint for query execution, defaulting to `https://node1.irys.xyz/graphql` for Irys and `https://gateway.irys.xyz/graphql` for Arweave.
+The `Query` class defaults to querying Irys' mainnet. To search Irys' devnet or Arweave, use the `network` parameter.
 
-When querying Irys, you must query the same node you uploaded to. To change the endpoint, pass any of the following to the `Query` object constructor:
-
--   https://node1.irys.xyz/graphql (Default)
--   https://node2.irys.xyz/graphql
--   https://devnet.irys.xyz/**graphql**
-
-When querying Arweave, any of these may be used:
-
--   https://arweave.net/graphql (Default)
--   https://arweave.dev/graphql
--   https://arweave-search.goldsky.com/graphql
+### Irys mainnet
 
 ```js
-const myQuery = new Query({ url: "https://devnet.irys.xyz/graphql" });
+// Either will work
+const myQuery = new Query();
+const myQuery = new Query({ network: "mainnet" });
+```
+
+### Irys devnet
+
+```js
+const myQuery = new Query({ network: "devnet" });
+```
+
+### Arweave
+
+```js
+const myQuery = new Query({ network: "arweave" });
 ```
 
 ## Query Type
 
 Using the `Query` class users can search any of:
 
--   Irys transactions
--   Arweave transactions
--   Arweave blocks
+- Irys transactions
+- Arweave transactions
+- Arweave blocks
 
 The search location is specified by passing a parameter to the [`search()`](/developer-docs/query-sdk/api/search) function.
 
@@ -98,10 +102,7 @@ const results = await myQuery
 Or by using UNIX timestamps in millisecond format:
 
 ```js
-const results = await myQuery
-	.search("irys:transactions")
-	.fromTimestamp(1688144401000)
-	.toTimestamp(1688317201000);
+const results = await myQuery.search("irys:transactions").fromTimestamp(1688144401000).toTimestamp(1688317201000);
 ```
 
 Irys timestamps are accurate to the millisecond, so you need to provide a timestamp in millisecond format. You can convert from human-readable time to UNIX timestamp using websites like [Epoch101](https://www.epoch101.com/), be sure to convert in **millisecond** format, not **second**.
@@ -113,9 +114,7 @@ Use the `tags()` function to search [metadata tags](https://docs.irys.xyz/develo
 Search for a single tag name / value pair:
 
 ```js
-const results = await myQuery
-	.search("irys:transactions")
-	.tags([{ name: "Content-Type", values: ["image/png"] }]);
+const results = await myQuery.search("irys:transactions").tags([{ name: "Content-Type", values: ["image/png"] }]);
 ```
 
 Search for a single tag name with a list of possible values. The search uses OR logic and returns transactions tagged with ANY provided value.
@@ -129,9 +128,10 @@ const results = await myQuery
 Search for multiple tags. The search uses AND logic and returns transactions tagged with ALL provided values.
 
 ```js
-const results = await myQuery.search("irys:transactions")
-	.tags([{ name: "Content-Type", values: ["image/png"] },
-		   { name: "Application-ID", values: ["myApp"] }]);
+const results = await myQuery.search("irys:transactions").tags([
+	{ name: "Content-Type", values: ["image/png"] },
+	{ name: "Application-ID", values: ["myApp"] },
+]);
 ```
 
 You can also search Arweave by tags:
@@ -175,9 +175,7 @@ const results = await myQuery
 When searching Arweave by transaction sender, only Arweave addresses are accepted:
 
 ```js
-const results = await myQuery
-	.search("arweave:transactions")
-	.from(["TrnCnIGq1tx8TV8NA7L2ejJJmrywtwRfq9Q7yNV6g2A"]);
+const results = await myQuery.search("arweave:transactions").from(["TrnCnIGq1tx8TV8NA7L2ejJJmrywtwRfq9Q7yNV6g2A"]);
 ```
 
 ## Transaction Recipient
@@ -185,9 +183,7 @@ const results = await myQuery
 Use the `to()` function to search for the wallet address of the transaction recipient. This works on Arweave only and is used when there's a fund transfer.
 
 ```js
-const results = await myQuery
-	.search("arweave:transactions")
-	.to("TrnCnIGq1tx8TV8NA7L2ejJJmrywtwRfq9Q7yNV6g2A");
+const results = await myQuery.search("arweave:transactions").to("TrnCnIGq1tx8TV8NA7L2ejJJmrywtwRfq9Q7yNV6g2A");
 ```
 
 ## Token
@@ -195,9 +191,7 @@ const results = await myQuery
 Irys accepts payment in 14 different tokens, these are all searchable using the `token()` function. Any of [these values](https://docs.irys.xyz/overview/supported-tokens) are acceptable.
 
 ```js
-const results = await myQuery
-	.search("irys:transactions")
-	.token("solana");
+const results = await myQuery.search("irys:transactions").token("solana");
 ```
 
 ## Block ID
@@ -266,10 +260,7 @@ Use the `stream()` function to manage large results sets. This function returns 
 
 ```js
 // Create the stream
-const stream = await myQuery
-	.search("irys:transactions")
-	.token("solana")
-	.stream();
+const stream = await myQuery.search("irys:transactions").token("solana").stream();
 
 // Iterate over the results
 for await (const result of stream) {

--- a/docs/src/zh/getting-started/quick-starts/hw-cli.md
+++ b/docs/src/zh/getting-started/quick-starts/hw-cli.md
@@ -8,7 +8,7 @@ locale: zh
 
 ## 要求
 
--   [NodeJS](https://nodejs.org) LTS 或更高版本
+- [NodeJS](https://nodejs.org) LTS 或更高版本
 
 ## 描述
 
@@ -37,5 +37,5 @@ echo "<h1>Hello Permaweb</h1>" > index.html
 ## 使用 Irys 上传
 
 ```sh
-irys upload index.html -c arweave -h https://node2.irys.xyz -w ./wallet.json
+irys upload index.html -c arweave -n mainnet -w ./wallet.json
 ```

--- a/docs/src/zh/getting-started/quick-starts/hw-code.md
+++ b/docs/src/zh/getting-started/quick-starts/hw-code.md
@@ -8,9 +8,9 @@ locale: zh
 
 ## 要求
 
--   [NodeJS](https://nodejs.org) LTS 或更高版本
--   基本的 HTML、CSS 和 JavaScript 知识
--   文本编辑器（VS Code、Sublime 或类似的）
+- [NodeJS](https://nodejs.org) LTS 或更高版本
+- 基本的 HTML、CSS 和 JavaScript 知识
+- 文本编辑器（VS Code、Sublime 或类似的）
 
 ## 说明
 
@@ -105,7 +105,7 @@ function changeColor() {
 以下命令将部署`src`目录，并将`index.html`文件作为清单的索引位置（相对于提供给`upload-dir`标志的路径）。
 
 ```sh
-irys upload-dir src -h https://node2.irys.xyz --index-file index.html -c arweave -w ./wallet.json
+irys upload-dir src -n mainnet --index-file index.html -c arweave -w ./wallet.json
 ```
 
 ## 恭喜！！

--- a/docs/src/zh/getting-started/quick-starts/hw-nodejs.md
+++ b/docs/src/zh/getting-started/quick-starts/hw-nodejs.md
@@ -10,7 +10,7 @@ locale: zh
 
 ## 要求
 
--   [NodeJS](https://nodejs.org) LTS 或更高版本
+- [NodeJS](https://nodejs.org) LTS 或更高版本
 
 ## 描述
 
@@ -39,7 +39,7 @@ import fs from "fs";
 const jwk = JSON.parse(fs.readFileSync("wallet.json").toString());
 
 const irys = new Irys({}
-  "http://node2.irys.xyz",
+	network: "mainnet", // Irys network, "mainnet" || "devnet"
   "arweave",
   jwk
 });
@@ -83,6 +83,6 @@ console.log(`https://arweave.net/${tx.id}`);
 
 ## 资源
 
--   [Irys Irys 软件开发工具包）](https://github.com/irys-xyz/js-sdk)
--   [Arweave JS SDK（Arweave JavaScript 软件开发工具包）](https://github.com/ArweaveTeam/arweave-js)
--   [Irys 文档：免费上传](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)
+- [Irys Irys 软件开发工具包）](https://github.com/irys-xyz/js-sdk)
+- [Arweave JS SDK（Arweave JavaScript 软件开发工具包）](https://github.com/ArweaveTeam/arweave-js)
+- [Irys 文档：免费上传](http://docs.irys.xyz/faqs/dev-faq#does-irys-offer-free-uploads)

--- a/docs/src/zh/guides/atomic-tokens/intro.md
+++ b/docs/src/zh/guides/atomic-tokens/intro.md
@@ -24,7 +24,10 @@ async function main() {
   const wallet = JSON.parse(await import('fs')
     .then(fs => fs.readFileSync('./wallet.json', 'utf-8')))
 
-  const irys = new Irys({ 'https://node2.irys.xyz', 'arweave', wallet })
+  const irys = new Irys({
+		network: 'mainnet', // Irys network, "mainnet" || "devnet"
+		'arweave',
+		wallet })
   const warp = WarpFactory.forMainnet()
 
   const data = `<h1>Hello Permaweb!</h1>`

--- a/docs/src/zh/guides/deployment/arkb.md
+++ b/docs/src/zh/guides/deployment/arkb.md
@@ -60,7 +60,7 @@ arkb deploy [folder] --wallet [钱包路径]
 
 要使用 irys 进行部署，您需要<a href="#fund-irys">为 Irys 节点提供资金</a>。
 
-Irys node2 允许在 100kb 以下的免费交易。
+Irys 允许在 100kb 以下的免费交易。
 
 您可以使用`tag-name/tag-value`语法为部署添加自定义标识标签。
 

--- a/docs/src/zh/guides/deployment/github-action.md
+++ b/docs/src/zh/guides/deployment/github-action.md
@@ -33,39 +33,34 @@ npm install --save-dev arweave
 创建`deploy.mjs`文件
 
 ```js
-import Irys from '@irys/sdk'
-import { WarpFactory, defaultCacheOptions } from 'warp-contracts'
-import Arweave from 'arweave'
+import Irys from "@irys/sdk";
+import { WarpFactory, defaultCacheOptions } from "warp-contracts";
+import Arweave from "arweave";
 
-const ANT = '[YOUR ANT CONTRACT]'
-const DEPLOY_FOLDER = './dist'
-const IRYS_NODE = 'https://node2.irys.xyz'
+const ANT = "[YOUR ANT CONTRACT]";
+const DEPLOY_FOLDER = "./dist";
+const IRYS_NETWORK = "mainnet"; // "mainnet" || "devnet"
 
-const arweave = Arweave.init({ host: 'arweave.net', port: 443, protocol: 'https' })
-const jwk = JSON.parse(Buffer.from(process.env.PERMAWEB_KEY, 'base64').toString('utf-8'))
+const arweave = Arweave.init({ host: "arweave.net", port: 443, protocol: "https" });
+const jwk = JSON.parse(Buffer.from(process.env.PERMAWEB_KEY, "base64").toString("utf-8"));
 
-const irys = new Irys({ IRYS_NODE, 'arweave', jwk })
-const warp = WarpFactory.custom(
-  arweave,
-  defaultCacheOptions,
-  'mainnet'
-).useArweaveGateway().build()
+const irys = new Irys({ network: IRYS_NETWORK, token: "arweave", key: jwk });
+const warp = WarpFactory.custom(arweave, defaultCacheOptions, "mainnet").useArweaveGateway().build();
 
-const contract = warp.contract(ANT).connect(jwk)
+const contract = warp.contract(ANT).connect(jwk);
 // 上传文件夹
 const result = await irys.uploadFolder(DEPLOY_FOLDER, {
-  indexFile: 'index.html'
-})
-
+	indexFile: "index.html",
+});
 
 // 更新ANT
 await contract.writeInteraction({
-  function: 'setRecord',
-  subDomain: '@',
-  transactionId: result.id
-})
+	function: "setRecord",
+	subDomain: "@",
+	transactionId: result.id,
+});
 
-console.log('已部署的食谱，请等待20-30分钟以进行ArNS更新！')
+console.log("已部署的食谱，请等待20-30分钟以进行ArNS更新！");
 ```
 
 ## 将脚本添加到 package.json
@@ -92,22 +87,22 @@ package.json
 name: publish
 
 on:
-    push:
-        branches:
-            - "main"
+  push:
+    branches:
+      - "main"
 
 jobs:
-    publish:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 18.x
-            - run: yarn
-            - run: yarn deploy
-              env:
-                  KEY: ${{ secrets.PERMAWEB_KEY }}
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - run: yarn
+      - run: yarn deploy
+        env:
+          KEY: ${{ secrets.PERMAWEB_KEY }}
 ```
 
 ## 总结
@@ -121,7 +116,7 @@ base64 -i wallet.json | pbcopy
 为了使此部署工作，您需要为此钱包的 Irys 账户提供资金，请确保钱包中有一些$AR，不要太多，也许0.5个$AR，然后使用 Irys cli 进行资金注入。
 
 ```console
-irys fund 250000000000 -h https://node2.irys.xyz -w wallet.json -t arweave
+irys fund 250000000000 -n mainnet -w wallet.json -t arweave
 ```
 
 ::: warning

--- a/docs/src/zh/guides/deployment/irys-cli.md
+++ b/docs/src/zh/guides/deployment/irys-cli.md
@@ -2,7 +2,7 @@
 locale: zh
 ---
 
-# Irys CLI (Previously Bundlr)
+# Irys CLI
 
 ## 要求
 

--- a/docs/src/zh/guides/posting-transactions/irys.md
+++ b/docs/src/zh/guides/posting-transactions/irys.md
@@ -39,7 +39,10 @@ import fs from "fs";
 let key = JSON.parse(fs.readFileSync("walletFile.txt").toString());
 
 // 初始化IrysSDK
-const irys = new Irys({ "http://node1.iryz.xyz", "arweave", key });
+const irys = new Irys({
+		network: "mainnet", // Irys network, "mainnet" || "devnet"
+		"arweave",
+		key });
 ```
 
 ## 发布捆绑交易
@@ -63,8 +66,8 @@ await tx.upload();
 
 ## 资源
 
--   有关发布交易的所有方式的概述，请参阅操作手册中的[发布交易](../../concepts/post-transactions.md)部分。
+- 有关发布交易的所有方式的概述，请参阅操作手册中的[发布交易](../../concepts/post-transactions.md)部分。
 
--   可以在[irys.xyz 网站](https://docs.irys.xyz/)上找到完整的 Irys 客户端文档。
+- 可以在[irys.xyz 网站](https://docs.irys.xyz/)上找到完整的 Irys 客户端文档。
 
--   使用 Irys 上传 NFT 合集的教程和工作坊[在此处](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts)。
+- 使用 Irys 上传 NFT 合集的教程和工作坊[在此处](http://docs.irys.xyz/hands-on/tutorials/uploading-nfts)。

--- a/docs/src/zh/guides/smartweave/warp/deploying-contracts.md
+++ b/docs/src/zh/guides/smartweave/warp/deploying-contracts.md
@@ -39,10 +39,10 @@ function deploy(initState, src) {
 
 通过 Warp SDK，您可以通过以下 4 种方式部署 SmartWeaveContract，这些选项处理开发人员可能遇到的不同用例。
 
--   需要同时部署具有相同源代码的合约
--   需要部署源代码已经在 permaweb 上的合约
--   需要通过序列器部署合约并使用路径清单将其指向某些数据
--   需要通过 Irys 部署合约并在序列器上注册该合约
+- 需要同时部署具有相同源代码的合约
+- 需要部署源代码已经在 permaweb 上的合约
+- 需要通过序列器部署合约并使用路径清单将其指向某些数据
+- 需要通过 Irys 部署合约并在序列器上注册该合约
 
 ::: 提示
 有关 Warp 部署的更多信息，请查看项目的 github 自述文件。[https://github.com/warp-contracts/warp#deployment](https://github.com/warp-contracts/warp#deployment)。
@@ -72,11 +72,11 @@ const { contractTxId, srcTxId } = await warp.deploy({
 });
 ```
 
--   wallet - 应该是 Arweave keyfile（wallet.json），解析为实现[JWK 接口](https://rfc-editor.org/rfc/rfc7517)的 JSON 对象或字符串'use_wallet'
--   initState - 是一个字符串化的 JSON 对象
--   data -如果你想将数据作为部署的一部分编写，这是可选的
--   src - 是合约的源代码的字符串或 Uint8Array 值
--   tags - 是一个包含名称/值对象`{name: string, value: string}[]`的数组，[了解更多关于标签的信息](../../../concepts/tags.md)
+- wallet - 应该是 Arweave keyfile（wallet.json），解析为实现[JWK 接口](https://rfc-editor.org/rfc/rfc7517)的 JSON 对象或字符串'use_wallet'
+- initState - 是一个字符串化的 JSON 对象
+- data -如果你想将数据作为部署的一部分编写，这是可选的
+- src - 是合约的源代码的字符串或 Uint8Array 值
+- tags - 是一个包含名称/值对象`{name: string, value: string}[]`的数组，[了解更多关于标签的信息](../../../concepts/tags.md)
 
 **deployFromSourceTx**
 
@@ -122,7 +122,10 @@ const { contractTxId } = await warp.deployBundled(dataItem.getRaw());
 ```ts
 import Irys from '@irys/sdk'
 
-const irys = new Irys({ 'https://node2.irys.xyz', 'arweave', wallet })
+const irys = new Irys({
+		network: 'mainnet', // Irys network, "mainnet" || "devnet"
+		'arweave',
+		wallet })
 const { id } = await irys.upload('Some Awesome Atomic Asset',  {
   tags: [{'Content-Type': 'text/plain' }]
 })

--- a/docs/src/zh/kits/react/create-react-app.md
+++ b/docs/src/zh/kits/react/create-react-app.md
@@ -8,15 +8,15 @@ locale: zh
 
 ## 先决条件
 
--   基本的 Typescript 知识（可选）- [https://www.typescriptlang.org/docs/](学习Typescript)
--   NodeJS v16.15.0 或更高版本-[https://nodejs.org/en/download/](下载NodeJS)
--   了解 ReactJS-[https://reactjs.org/](学习ReactJS)
--   了解 git 和常用的终端命令
+- 基本的 Typescript 知识（可选）- [https://www.typescriptlang.org/docs/](学习Typescript)
+- NodeJS v16.15.0 或更高版本-[https://nodejs.org/en/download/](下载NodeJS)
+- 了解 ReactJS-[https://reactjs.org/](学习ReactJS)
+- 了解 git 和常用的终端命令
 
 ## 开发依赖
 
--   TypeScript
--   NPM 或 Yarn 软件包管理器
+- TypeScript
+- NPM 或 Yarn 软件包管理器
 
 ## 步骤
 
@@ -238,7 +238,7 @@ yarn global add @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./build -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./build -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
   ...
 }
@@ -298,14 +298,14 @@ yarn deploy
   <CodeGroupItem title="NPM">
   
 ```console:no-line-numbers
-irys fund 1479016 -h https://node1.irys.xyz -w wallet.json -c arweave
+irys fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>
   <CodeGroupItem title="YARN">
   
 ```console:no-line-numbers
-irys fund 1479016 -h https://node1.irys.xyz -w wallet.json -c arweave
+irys fund 1479016 -n mainnet -w wallet.json -c arweave
 ```
 
   </CodeGroupItem>

--- a/docs/src/zh/kits/react/vite.md
+++ b/docs/src/zh/kits/react/vite.md
@@ -8,15 +8,15 @@ locale: zh
 
 ## 先决条件
 
--   基本的 TypeScript 知识（非必需）- [https://www.typescriptlang.org/docs/](了解 TypeScript)
--   NodeJS v16.15.0 或更高版本- [https://nodejs.org/en/download/](下载 NodeJS)
--   了解 ReactJS- [https://reactjs.org/](了解 ReactJS)
--   知道 git 和常见的终端命令
+- 基本的 TypeScript 知识（非必需）- [https://www.typescriptlang.org/docs/](了解 TypeScript)
+- NodeJS v16.15.0 或更高版本- [https://nodejs.org/en/download/](下载 NodeJS)
+- 了解 ReactJS- [https://reactjs.org/](了解 ReactJS)
+- 知道 git 和常见的终端命令
 
 ## 开发依赖
 
--   TypeScript
--   NPM 或 Yarn 包管理器
+- TypeScript
+- NPM 或 Yarn 包管理器
 
 ## 步骤
 
@@ -255,7 +255,7 @@ yarn global add @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir ./dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir ./dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
   ...
 }

--- a/docs/src/zh/kits/svelte/minimal.md
+++ b/docs/src/zh/kits/svelte/minimal.md
@@ -8,17 +8,17 @@ locale: zh
 
 ## 先决条件
 
--   熟悉 Typescript
--   NodeJS v18 或更高版本
--   了解 Svelte - [https://svelte.dev](https://svelte.dev)
--   了解 git 和常用终端命令
+- 熟悉 Typescript
+- NodeJS v18 或更高版本
+- 了解 Svelte - [https://svelte.dev](https://svelte.dev)
+- 了解 git 和常用终端命令
 
 ## 开发依赖
 
--   TypeScript
--   esbuild
--   w3
--   yarn `npm i -g yarn`
+- TypeScript
+- esbuild
+- w3
+- yarn `npm i -g yarn`
 
 ## 步骤
 
@@ -168,7 +168,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.xyz --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/zh/kits/svelte/vite.md
+++ b/docs/src/zh/kits/svelte/vite.md
@@ -210,7 +210,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "yarn build && irys upload-dir dist -h https://node2.irys.sdk --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "yarn build && irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```

--- a/docs/src/zh/kits/vue/create-vue.md
+++ b/docs/src/zh/kits/vue/create-vue.md
@@ -8,15 +8,15 @@ locale: zh
 
 ## 先决条件
 
--   基本的 Typescript 知识（非强制）- [学习 Typescript](https://www.typescriptlang.org/docs/)
--   NodeJS v16.15.0 或以上版本- [下载 NodeJS](https://nodejs.org/en/download/)
--   Vue.js 知识（最好是 Vue 3）- [学习 Vue.js](https://vuejs.org/)
--   了解 git 和常用终端命令
+- 基本的 Typescript 知识（非强制）- [学习 Typescript](https://www.typescriptlang.org/docs/)
+- NodeJS v16.15.0 或以上版本- [下载 NodeJS](https://nodejs.org/en/download/)
+- Vue.js 知识（最好是 Vue 3）- [学习 Vue.js](https://vuejs.org/)
+- 了解 git 和常用终端命令
 
 ## 开发依赖项
 
--   TypeScript（可选）
--   NPM 或 Yarn 软件包管理器
+- TypeScript（可选）
+- NPM 或 Yarn 软件包管理器
 
 ## 步骤
 
@@ -202,7 +202,7 @@ yarn add -D @irys/sdk
   ...
   "scripts": {
     ...
-    "deploy": "irys upload-dir dist -h https://node2.irys.sdk --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
+    "deploy": "irys upload-dir dist -n mainnet --wallet ./wallet.json -c arweave --index-file index.html --no-confirmation"
   }
 }
 ```
@@ -269,7 +269,7 @@ yarn deploy
 
 此位置有一个完整的 JavaScript 或 TypeScript 示例。
 
--   代码库：[https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
+- 代码库：[https://github.com/ItsAnunesS/permaweb-create-vue-starter](https://github.com/ItsAnunesS/permaweb-create-vue-starter)
 
 ## 摘要
 


### PR DESCRIPTION
This update brings the cookbook in line with the latest Irys SDK. Irys recently merged its two mainnet nodes into one. You no longer need to specify a node URL when creating a new Irys object, you only need to indicate if you're using mainnet or devnet.

Note, this update is backward compatible. If you have projects using the Irys SDK, you don't need to update your code.

https://docs.irys.xyz/developer-docs/network-merge-guide