### PR TITLE
Docs(Manifests): Updated manifest references to v0.2.0, added Turbo guide

### DIFF
--- a/docs/src/.vuepress/sidebar.js
+++ b/docs/src/.vuepress/sidebar.js
@@ -215,6 +215,10 @@ const getI18NSidebar = (langCode) => [
 						text: "Akord",
 						link: get_i18n_link(langCode, "/guides/deploying-manifests/akord"),
 					},
+					{
+						text: "Turbo",
+						link: get_i18n_link(langCode, "/guides/deploying-manifests/turbo"),
+					},
 				],
 			},
 			{

--- a/docs/src/concepts/manifests.md
+++ b/docs/src/concepts/manifests.md
@@ -49,9 +49,12 @@ and having JSON formatted transaction data that matches the example below.
 ```json
 {
   "manifest": "arweave/paths",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "index": {
     "path": "index.html"
+  },
+  "fallback": {
+    "id": "cG7Hdi_iTQPoEYgQJFqJ8NMpN4KoZ-vH_j7pG4iP7NI"
   },
   "paths": {
     "index.html": {

--- a/docs/src/concepts/manifests.md
+++ b/docs/src/concepts/manifests.md
@@ -79,6 +79,10 @@ and having JSON formatted transaction data that matches the example below.
 }
 ```
 
+- **fallback:**
+
+Manifest version 0.2.0 introduced the `fallback` attribute. `fallback` is an object that accepts the sub attribute `id`, which defines an Arweave data item transaction id for the resolver to fall back to if it fails to correctly resolve a requested path.
+
 Source and Further Reading in the official Arweave Path Manifest docs: [Arweave Docs](https://github.com/ArweaveTeam/arweave/blob/master/doc/path-manifest-schema.md)
 
 

--- a/docs/src/guides/deploying-manifests/akord.md
+++ b/docs/src/guides/deploying-manifests/akord.md
@@ -113,10 +113,13 @@ const akord = await Akord.init(wallet);
 // let's define our manifest
 const manifest = {
   "manifest": "arweave/paths",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "index": {
     "path": "index.html"
   },
+  "fallback": {
+    "id": "cG7Hdi_iTQPoEYgQJFqJ8NMpN4KoZ-vH_j7pG4iP7NI"
+  }
   "paths": {
     "index.html": {
       "id": "cG7Hdi_iTQPoEYgQJFqJ8NMpN4KoZ-vH_j7pG4iP7NI"

--- a/docs/src/guides/deploying-manifests/turbo.md
+++ b/docs/src/guides/deploying-manifests/turbo.md
@@ -1,0 +1,122 @@
+# Deploying Manifests with Turbo
+
+## Installing Turbo
+
+> Requires NodeJS - https://nodejs.org
+
+<CodeGroup>
+  <CodeGroupItem title="NPM">
+
+```console
+npm install @ardrive/turbo-sdk
+```
+
+  </CodeGroupItem>
+  <CodeGroupItem title="YARN">
+
+```console
+yarn add @ardrive/turbo-sdk
+```
+
+  </CodeGroupItem>
+</CodeGroup>
+
+## Upload Folder
+
+By default, the `uploadFolder` method in the Turbo SDK will generate and deploy a manifest for the folder. The `index` and `fallback` attributes will be set to the `index.html` and `404.html` files, respectively, in the uploaded folder unless other files are specified.
+
+The `uploadFolder` method will return both the full json for the manifest, and the transaction id for the manifest upload.
+
+```javascript
+import { TurboFactory } from "@ardrive/turbo-sdk";
+import fs from "fs";
+
+const jwk = fs.readFileSync("./KeyFile.json");
+const turbo = TurboFactory.authenticated({ privateKey: JSON.parse(jwk) });
+
+const { manifest, fileResponses, manifestResponse } = await turbo.uploadFolder({
+  folderPath,
+  dataItemOpts: {
+    // optional
+    tags: [
+      {
+        // User defined content type will overwrite file content type
+        name: "Content-Type",
+        value: "text/plain",
+      },
+      {
+        name: "My-Custom-Tag",
+        value: "my-custom-value",
+      },
+    ],
+    // no timeout or AbortSignal provided
+  },
+  manifestOptions: {
+    // optional
+    indexFile: "custom-index.html",
+    fallbackFile: "custom-fallback.html",
+    disableManifests: false,
+  },
+});
+```
+
+## Manually Create and Upload a Manifest
+
+Manifests can also be manually created and uploaded. A manifest is a json object with specific schema and uploaded with the `Content-Type` tag `application/x.arweave-manifest+json`.
+
+```js
+import { TurboFactory } from "@ardrive/turbo-sdk";
+import { Readable } from 'stream';
+
+
+const jwk = fs.readFileSync('./KeyFile.json');
+const turbo = TurboFactory.authenticated({ privateKey: JSON.parse(jwk) });
+
+// define the manifest
+const manifest = {
+  "manifest": "arweave/paths",
+  "version": "0.2.0",
+  "index": {
+    "path": "index.html"
+  },
+  "fallback": {
+    "id": "-u47dfkUE2k9vETNXTqCdFRVLS5NfpZfODZ5ZKItiRY"
+  }
+   "paths": {
+      "404.html": {
+        "id": "-u47dfkUE2k9vETNXTqCdFRVLS5NfpZfODZ5ZKItiRY"
+      },
+      "index.html": {
+        "id": "dYD2PqQyFpKj40bhyTkBCEtYnxf-GfQpRMFClbCiHF4"
+      },
+      "last.html": {
+        "id": "YjpkqFPUamchyDYpJsGUmge8sKczqTKkX2hWbIL9qBw"
+      },
+      "stuff.html": {
+        "id": "pqnejz6_iHB-KYdTB4zC_ALEX5Ox-Rpt4X_Yr3JZywk"
+      },
+      "test.html": {
+        "id": "hfc763dACTF9VvxDAX4YkF9QNzh5eO1NZpSCAetsrXE"
+      }
+    }
+};
+
+// upload the manifest
+const manifestString = JSON.stringify(manifest);
+
+const uploadResult = await turbo.uploadFile({
+	fileStreamFactory: () => Readable.from(Buffer.from(manifestString)),
+	fileSizeFactory: () => Buffer.byteLength(manifestString),
+	signal: AbortSignal.timeout(10_000), //10 second timeout
+	dataItemOpts: {
+		tags: [
+				{
+					name: 'Content-Type',
+					value: 'application/x.arweave-manifest+json',
+				}
+			],
+		},
+});
+
+console.log(uploadResult.id) // log the manifest transaction id to the console
+```


### PR DESCRIPTION
Manifests recently received an upgrade that allows them to support a "fallback" id, which resolvers will use in place of a requested path that cannot be found, effectively acting as a 404 page.

This pr updates references to manually created manifests to show the updated version and include the "fallback" attribute. It also adds a guide page for creating and deploying a manifest using the Turbo SDK.