### PR TITLE
Update arconnect references

### DIFF
--- a/docs/src/concepts/arfs/privacy.md
+++ b/docs/src/concepts/arfs/privacy.md
@@ -23,7 +23,7 @@ Private drives have a global drive key, `D`, and multiple file keys `F`, for enc
 
 <img :src="$withBase('/encryption-diagram.png')" style="height: auto; display: block; margin-left: auto; margin-right: auto; width: 75%;">
 
-Other wallets (like [ArConnect](https://www.arconnect.io/)) integrate with this Key Derivation protocol just exposing an API to collect a signature from a given Arweave Wallet in order to get the SHA-256 signature needed for the [HKDF](https://en.wikipedia.org/wiki/HKDF) to derive the Drive Key.
+Other wallets (like [Wander](https://wander.app/)) integrate with this Key Derivation protocol just exposing an API to collect a signature from a given Arweave Wallet in order to get the SHA-256 signature needed for the [HKDF](https://en.wikipedia.org/wiki/HKDF) to derive the Drive Key.
 
 An example implementation, using Dart, is available [here](https://github.com/ardriveapp/ardrive-web/blob/187b3fb30808bda452123c2b18931c898df6a3fb/docs/private_drive_kdf_reference.dart), with a Typescript implementation [here](https://github.com/ardriveapp/ardrive-core-js/blob/f19da30efd30a4370be53c9b07834eae764f8535/src/utils/crypto.ts).
 

--- a/docs/src/concepts/keyfiles-and-wallets.md
+++ b/docs/src/concepts/keyfiles-and-wallets.md
@@ -51,7 +51,7 @@ Interestingly the address of your wallet is derived from its **public key**. Whi
 ### Wallets
 [Arweave.app](https://arweave.app/welcome) - Arweave web wallet to deploy permanent data, connect your accounts securely to decentralized applications, and navigate the weave.
 
-[ArConnect](https://www.arconnect.io/) - Arweave Wallet Browser Extension
+[Wander](https://wander.app) - Browser extension and mobile wallet for Arweave and AO
 
 ### Sources and Further Reading:
 [Arweave Docs](https://docs.arweave.org/developers/server/http-api#key-format)

--- a/docs/src/getting-started/quick-starts/hw-no-code.md
+++ b/docs/src/getting-started/quick-starts/hw-no-code.md
@@ -10,7 +10,7 @@ In this quick start we are going to upload an image to the permaweb with no code
 
 ## Create a wallet
 
-[https://arweave.app/add](https://arweave.app/add) or [https://arconnect.io](https://arconnect.io)
+[https://arweave.app/add](https://arweave.app/add) or [https://wander.app](https://wander.app)
 
 ## Send some data to arweave
 


### PR DESCRIPTION
Some areas of the docs contain references to ArConnect which has now rebranded to Wander. 

This PR updates the old references and links to Wander instead, as well as updates some of the descriptions to better reflect what Wander is (e.g. it is now a mobile wallet, too).