### PR TITLE
Update Getting Started section

### DIFF
--- a/docs/src/getting-started/README.md
+++ b/docs/src/getting-started/README.md
@@ -4,7 +4,9 @@
 
 # Cooking with the Permaweb
 
-The Permaweb Cookbook is a developer resource that provides the essential concepts and references for building applications on the Permaweb. Each concept and reference will focus on specific aspects of the Permaweb development ecosystem while providing additional details and usage examples.
+The Permaweb Cookbook is a developer resource that provides the essential concepts and references for building applications on Arweave. Each concept and reference will focus on specific aspects of the Permaweb development ecosystem while providing additional details and usage examples.
+
+For those interested in creating smart contracts in particular, consider checking out the [AO Cookbook](https://cookbook_ao.arweave.net) which covers the decentralized compute platform built on top of AO. 
 
 ## Developers
 
@@ -16,7 +18,7 @@ Welcome to the Arweave development community, where the past is forever etched i
 
 The Cookbook is designed in a way that makes it easy for new Permaweb developers to contribute. Even if you don't know how to do something, contributing to the cookbook is a great way to learn!
 
-Check out all open issues here. Contribution guidelines here. If you find the cookbook is missing a concept, guide or reference, please add an issue.
+Check out all open issues [here](https://github.com/twilson63/permaweb-cookbook/issues). Contribution guidelines [here](https://github.com/twilson63/permaweb-cookbook/blob/main/CONTRIBUTING.md). If you find the cookbook is missing a concept, guide or reference, please add an issue.
 
 [Read More](contributing.md)
 


### PR DESCRIPTION
This PR fixes some typos/grammar mistakes on the getting started page, as well as adding in missing links and rewriting some of the introduction section.