### PR TITLE
Add Permaweb Glossary and LLMs.txt Reference Pages

### DIFF
--- a/docs/languages/strings/en.json
+++ b/docs/languages/strings/en.json
@@ -68,5 +68,6 @@
   "guides-api-token": "Api Token",
   "guides-testing": "Testing",
   "references": "References",
+  "references-llms": "LLMs Documentation",
   "kits": "Starter Kits"
 }

--- a/docs/src/.vuepress/sidebar.js
+++ b/docs/src/.vuepress/sidebar.js
@@ -295,6 +295,16 @@ const getI18NSidebar = (langCode) => [
 				collapsible: false,
 				link: get_i18n_link(langCode, "/references/http-api.html"),
 			},
+			{
+				text: "LLMs.txt",
+				collapsible: false,
+				link: get_i18n_link(langCode, "/references/llms.html"),
+			},
+			{
+				text: "Glossary",
+				collapsible: false,
+				link: get_i18n_link(langCode, "/references/glossary.html"),
+			},
 		],
 	},
 	{

--- a/docs/src/references/glossary.md
+++ b/docs/src/references/glossary.md
@@ -1,0 +1,20 @@
+# Glossary
+
+The following is an embedded glossary tool for the permaweb ecosystem. It supports both light and dark mode, matching the documentation theme.
+
+<style>
+  .glossary-iframe {
+    height: 500px;
+    width: 100%;
+    border: none;
+  }
+  html:not(.dark) .dark-mode-iframe {
+    display: none;
+  }
+  html.dark .light-mode-iframe {
+    display: none;
+  }
+</style>
+
+<iframe class="glossary-iframe light-mode-iframe" src="https://glossary.arweave.net/?hide-header=true&bg-color=%23f2f2f2&text-color=%23242424&link-color=%23ff5f15&border-color=%23c7c9cc&hover-bg=%23e0e2e3&category-bg=%23e0e2e3&category-text=%233a3a3a&input-bg=%23f2f2f2&result-bg=%23f2f2f2&result-hover=%23e0e2e3&heading-color=%23242424&tag-bg=%23c7c9cc&tag-text=%23f2f2f2&button-bg=%23c7c9cc&button-text=%23f2f2f2&accent-color=%23ff5f15&secondary-text=%235c5c5c"></iframe>
+<iframe class="glossary-iframe dark-mode-iframe" src="https://glossary.arweave.net/?hide-header=true&link-color=%2334d399&bg-color=%231b1b1f&text-color=%23e0e0e0&border-color=%23444444&hover-bg=%23222222&heading-color=%23ffffff&button-bg=%23444444&button-text=%23ffffff&section-bg=%23333333&section-color=%23ffffff&category-bg=%23333333&category-text=%23ffffff&tag-bg=%233a3a3a&tag-text=%23e0e0e0&secondary-text=%23a0a0a0&result-bg=%231e1e1e&result-hover=%23333333"></iframe> 

--- a/docs/src/references/llms.md
+++ b/docs/src/references/llms.md
@@ -19,7 +19,7 @@ The following is a [tool](https://fuel_permawebllms.arweave.net) that allows you
 
 <iframe
   class="llms-iframe light-mode-iframe"
-  src="https://fuel_permawebllms.arweave.net/?minimal=true&iframe=true&bg-color=%23f2f2f2&text-color=%23222222&accent=%23e77b40"
+  src="https://fuel_permawebllms.arweave.net/?minimal=true&iframe=true&bg-color=%23f2f2f2&text-color=%23222222&accent-color=%23ff5f15"
   title="Permaweb LLMs Builder (Light Mode)"
   height="250"
   allowfullscreen
@@ -27,7 +27,7 @@ The following is a [tool](https://fuel_permawebllms.arweave.net) that allows you
 ></iframe>
 <iframe
   class="llms-iframe dark-mode-iframe"
-  src="https://fuel_permawebllms.arweave.net/?minimal=true&iframe=true&bg-color=%231b1b1f&text-color=%23e0e0e0&accent=%23e77b40"
+  src="https://fuel_permawebllms.arweave.net/?minimal=true&iframe=true&bg-color=%231b1b1f&text-color=%23e0e0e0&accent-color=%23ff8851"
   title="Permaweb LLMs Builder (Dark Mode)"
   height="250"
   allowfullscreen

--- a/docs/src/references/llms.md
+++ b/docs/src/references/llms.md
@@ -1,0 +1,35 @@
+# LLMs.txt
+
+The following is a [tool](https://permaweb-llms-builder.arweave.net) that allows you to build your own LLMs.txt files based on docs from the permaweb ecosystem.
+
+<style>
+  .llms-iframe {
+    width: 100%;
+    height: 250px;
+    border: none;
+    padding-top: 0;
+  }
+  html:not(.dark) .dark-mode-iframe {
+    display: none;
+  }
+  html.dark .light-mode-iframe {
+    display: none;
+  }
+</style>
+
+<iframe
+  class="llms-iframe light-mode-iframe"
+  src="https://permaweb-llms-builder.vercel.app/?minimal=true&iframe=true&bg-color=%23f2f2f2&text-color=%23222222&accent=%23e77b40"
+  title="Permaweb LLMs Builder (Light Mode)"
+  height="250"
+  allowfullscreen
+  loading="lazy"
+></iframe>
+<iframe
+  class="llms-iframe dark-mode-iframe"
+  src="https://permaweb-llms-builder.vercel.app/?minimal=true&iframe=true&bg-color=%231b1b1f&text-color=%23e0e0e0&accent=%23e77b40"
+  title="Permaweb LLMs Builder (Dark Mode)"
+  height="250"
+  allowfullscreen
+  loading="lazy"
+></iframe> 

--- a/docs/src/references/llms.md
+++ b/docs/src/references/llms.md
@@ -19,7 +19,7 @@ The following is a [tool](https://permaweb-llms-builder.arweave.net) that allows
 
 <iframe
   class="llms-iframe light-mode-iframe"
-  src="https://permaweb-llms-builder.vercel.app/?minimal=true&iframe=true&bg-color=%23f2f2f2&text-color=%23222222&accent=%23e77b40"
+  src="https://permaweb-llms-builder.arweave.net/?minimal=true&iframe=true&bg-color=%23f2f2f2&text-color=%23222222&accent=%23e77b40"
   title="Permaweb LLMs Builder (Light Mode)"
   height="250"
   allowfullscreen
@@ -27,7 +27,7 @@ The following is a [tool](https://permaweb-llms-builder.arweave.net) that allows
 ></iframe>
 <iframe
   class="llms-iframe dark-mode-iframe"
-  src="https://permaweb-llms-builder.vercel.app/?minimal=true&iframe=true&bg-color=%231b1b1f&text-color=%23e0e0e0&accent=%23e77b40"
+  src="https://permaweb-llms-builder.arweave.net/?minimal=true&iframe=true&bg-color=%231b1b1f&text-color=%23e0e0e0&accent=%23e77b40"
   title="Permaweb LLMs Builder (Dark Mode)"
   height="250"
   allowfullscreen

--- a/docs/src/references/llms.md
+++ b/docs/src/references/llms.md
@@ -1,6 +1,6 @@
 # LLMs.txt
 
-The following is a [tool](https://permaweb-llms-builder.arweave.net) that allows you to build your own LLMs.txt files based on docs from the permaweb ecosystem.
+The following is a [tool](https://fuel_permawebllms.arweave.net) that allows you to build your own LLMs.txt files based on docs from the permaweb ecosystem.
 
 <style>
   .llms-iframe {
@@ -19,7 +19,7 @@ The following is a [tool](https://permaweb-llms-builder.arweave.net) that allows
 
 <iframe
   class="llms-iframe light-mode-iframe"
-  src="https://permaweb-llms-builder.arweave.net/?minimal=true&iframe=true&bg-color=%23f2f2f2&text-color=%23222222&accent=%23e77b40"
+  src="https://fuel_permawebllms.arweave.net/?minimal=true&iframe=true&bg-color=%23f2f2f2&text-color=%23222222&accent=%23e77b40"
   title="Permaweb LLMs Builder (Light Mode)"
   height="250"
   allowfullscreen
@@ -27,7 +27,7 @@ The following is a [tool](https://permaweb-llms-builder.arweave.net) that allows
 ></iframe>
 <iframe
   class="llms-iframe dark-mode-iframe"
-  src="https://permaweb-llms-builder.arweave.net/?minimal=true&iframe=true&bg-color=%231b1b1f&text-color=%23e0e0e0&accent=%23e77b40"
+  src="https://fuel_permawebllms.arweave.net/?minimal=true&iframe=true&bg-color=%231b1b1f&text-color=%23e0e0e0&accent=%23e77b40"
   title="Permaweb LLMs Builder (Dark Mode)"
   height="250"
   allowfullscreen


### PR DESCRIPTION
### Summary
This PR adds two new reference pages to the permaweb cookbook documentation: a Permaweb Glossary and an LLMs.txt builder tool, both with proper light/dark mode theming integration.

### Changes Made

#### New Pages Added
- **`docs/src/references/glossary.md`** - Embedded Permaweb Glossary tool

- **`docs/src/references/llms.md`** - LLMs.txt Builder tool

### Technical Details
- Both iframes use CSS classes for light/dark mode switching
- Color parameters match the project's CSS variables:
  - Light mode: `--c-bg: #f2f2f2`, `--c-text: #242424`, `--c-brand: #ff5f15`
  - Dark mode: `--c-bg: #1b1b1f`, `--c-text: #e0e0e0`
- Responsive design with proper iframe styling
- No header display on glossary for seamless integration
