### PR TITLE
Remove atomic assets link from community page

### DIFF
--- a/docs/src/community/README.md
+++ b/docs/src/community/README.md
@@ -8,5 +8,3 @@ If you've created something on the Permaweb, and would like to add documentation
 
 ## Community Contributions
 - [Arweave Name System (ArNS)](../concepts/arns.md)
-- [Atomic Assets](../guides/smartweave/atomic-assets/index.md)
-  - [using ArDrive CLI](../guides/smartweave/atomic-assets/ardrive-cli.md)


### PR DESCRIPTION
As the Atomic Assets guides are currently referencing SmartWeave, I think it makes sense to remove the link so we aren't pointing users towards outdated content.