### PR TITLE
Move ARFS to Community in sidebar

### DIFF
--- a/docs/src/.vuepress/sidebar.js
+++ b/docs/src/.vuepress/sidebar.js
@@ -105,37 +105,6 @@ const getI18NSidebar = (langCode) => [
 				],
 			},
 			{
-				text: "Arweave File System (ArFS)",
-				link: get_i18n_link(langCode, "/concepts/arfs/arfs.html"),
-				collapsible: true,
-				children: [
-					{
-						text: "ArFS",
-						link: get_i18n_link(langCode, "/concepts/arfs/arfs.html"),
-					},
-					{
-						text: "Data Model",
-						link: get_i18n_link(langCode, "/concepts/arfs/data-model.html"),
-					},
-					{
-						text: "Entity Types",
-						link: get_i18n_link(langCode, "/concepts/arfs/entity-types.html"),
-					},
-					{
-						text: "Content Types",
-						link: get_i18n_link(langCode, "/concepts/arfs/content-types.html"),
-					},
-					{
-						text: "Privacy",
-						link: get_i18n_link(langCode, "/concepts/arfs/privacy.html"),
-					},
-					{
-						text: "Schema Diagrams",
-						link: get_i18n_link(langCode, "/concepts/arfs/schema-diagrams.html"),
-					},
-				],
-			},
-			{
 				text: get_i18n_str(langCode, "concepts-vouch", "Vouch"),
 				link: get_i18n_link(langCode, "/concepts/vouch.html"),
 			}
@@ -287,6 +256,37 @@ const getI18NSidebar = (langCode) => [
 			{
 				text: "Arweave Name System (ArNS)",
 				link: get_i18n_link(langCode, "/concepts/arns.html"),
+			},
+			{
+				text: "Arweave File System (ArFS)",
+				link: get_i18n_link(langCode, "/concepts/arfs/arfs.html"),
+				collapsible: true,
+				children: [
+					{
+						text: "ArFS",
+						link: get_i18n_link(langCode, "/concepts/arfs/arfs.html"),
+					},
+					{
+						text: "Data Model",
+						link: get_i18n_link(langCode, "/concepts/arfs/data-model.html"),
+					},
+					{
+						text: "Entity Types",
+						link: get_i18n_link(langCode, "/concepts/arfs/entity-types.html"),
+					},
+					{
+						text: "Content Types",
+						link: get_i18n_link(langCode, "/concepts/arfs/content-types.html"),
+					},
+					{
+						text: "Privacy",
+						link: get_i18n_link(langCode, "/concepts/arfs/privacy.html"),
+					},
+					{
+						text: "Schema Diagrams",
+						link: get_i18n_link(langCode, "/concepts/arfs/schema-diagrams.html"),
+					},
+				],
 			}
 		]
 	},

--- a/docs/src/community/README.md
+++ b/docs/src/community/README.md
@@ -8,3 +8,4 @@ If you've created something on the Permaweb, and would like to add documentation
 
 ## Community Contributions
 - [Arweave Name System (ArNS)](../concepts/arns.md)
+- [ArFS](../concepts/arfs.md)

--- a/docs/src/community/README.md
+++ b/docs/src/community/README.md
@@ -8,4 +8,4 @@ If you've created something on the Permaweb, and would like to add documentation
 
 ## Community Contributions
 - [Arweave Name System (ArNS)](../concepts/arns.md)
-- [ArFS](../concepts/arfs.md)
+- [Arweave File System (ArFS)](../concepts/arfs.md)


### PR DESCRIPTION
In relation to issue #371 - instead of removing ArFS from the cookbook entirely, for now I think we can move it to the community section.

This updates the sidebar to move ArFS to the community section, and adds a link on the community section to ArFS.
