### PR TITLE
fix: fix links in documentation

### DIFF
--- a/src/.vuepress/sidebar.js
+++ b/src/.vuepress/sidebar.js
@@ -81,7 +81,31 @@ const getI18NSidebar = (langCode) => [
             link: get_i18n_link(
               langCode,
               '/fundamentals/transactions/post-transactions.html'
-            )
+            ),
+            collapsible: true,
+            children: [
+              {
+                text: 'arweave-js',
+                link: get_i18n_link(
+                  langCode,
+                  '/fundamentals/transactions/arweave-js.html'
+                )
+              },
+              {
+                text: 'dispatch',
+                link: get_i18n_link(
+                  langCode,
+                  '/fundamentals/transactions/dispatch.html'
+                )
+              },
+              {
+                text: 'Turbo SDK',
+                link: get_i18n_link(
+                  langCode,
+                  '/fundamentals/transactions/turbo.html'
+                )
+              }
+            ]
           },
           {
             text: get_i18n_str(langCode, 'concepts-tags'),

--- a/src/fundamentals/accessing-arweave-data/index.md
+++ b/src/fundamentals/accessing-arweave-data/index.md
@@ -95,5 +95,4 @@ All these access methods are provided by Arweave gateways. Gateways can be:
 
 ## Additional Resources
 
-- [Querying Arweave Guide](../../guides/querying-arweave/querying-arweave.md)
-- [GraphQL Reference](../../references/gql.md)
+- [Querying Arweave Guide](../../tooling/querying-arweave.md)

--- a/src/fundamentals/decentralized-computing/ao-processes/state-management.md
+++ b/src/fundamentals/decentralized-computing/ao-processes/state-management.md
@@ -1096,8 +1096,8 @@ Users[address] = {
 
 Master advanced AO concepts:
 
-1. **HyperBEAM Integration** - [HyperBEAM Introduction](/concepts/decentralized-computing/hyperbeam/hyperbeam-introduction)
-2. **Lua Serverless Functions** - [Lua Serverless](/concepts/decentralized-computing/hyperbeam/lua-serverless)
+1. **HyperBEAM Integration** - [HyperBEAM Introduction](../hyperbeam/hyperbeam-introduction.md)
+2. **Lua Serverless Functions** - [Lua Serverless](../hyperbeam/lua-serverless.md)
 3. **Production Patterns** - [Builder's Journey](/guides/builder-journey/)
 4. **Performance Optimization** - [Advanced Optimization](/guides/performance-optimization/)
 

--- a/src/fundamentals/decentralized-computing/ao-processes/what-are-ao-processes.md
+++ b/src/fundamentals/decentralized-computing/ao-processes/what-are-ao-processes.md
@@ -8,7 +8,7 @@ timeEstimate: "25 minutes"
 
 # What are AO Processes
 
-AO processes are autonomous compute units that run on the Arweave network, enabling decentralized applications to execute complex logic permanently and trustlessly. Think of them as serverless functions that never go down and can maintain state across invocations.
+[AO processes](https://cookbook_ao.arweave.net/welcome/ao-processes.html) are autonomous compute units that run on the Arweave network, enabling decentralized applications to execute complex logic permanently and trustlessly. Think of them as serverless functions that never go down and can maintain state across invocations.
 
 ## Core Architecture
 
@@ -627,14 +627,11 @@ Handlers.add(
 
 Now that you understand AO processes fundamentals:
 
-1. **Learn process communication** - [Process Communication](/fundamentals/decentralized-computing/ao-processes/process-communication)
-2. **Master state management** - [State Management](/fundamentals/decentralized-computing/ao-processes/state-management)  
-3. **Explore HyperBEAM** - [HyperBEAM Introduction](/concepts/decentralized-computing/hyperbeam/hyperbeam-introduction)
-4. **Build your first process** - [Builder's Journey](/guides/builder-journey/)
+1. **Master state management** - [State Management](./state-management.md)  
+2. **Explore HyperBEAM** - [HyperBEAM Introduction](../hyperbeam/hyperbeam-introduction.md)
 
 ## Resources
 
-- **AO Documentation**: [Official AO Docs](https://ao.arweave.net)
-- **AOS (AO Studio)**: [Development Environment](https://github.com/permaweb/aos)
+- **AO Documentation**: [Official AO Docs](https://cookbook_ao.arweave.net)
+- **AOS (AO CLI)**: [Development Environment](https://github.com/permaweb/aos)
 - **Code Examples**: [AO Cookbook Repository](https://github.com/permaweb/ao-cookbook)
-- **Community**: [AO Discord Channel](https://discord.gg/arweave)

--- a/src/fundamentals/decentralized-computing/hyperbeam/hyperbeam-introduction.md
+++ b/src/fundamentals/decentralized-computing/hyperbeam/hyperbeam-introduction.md
@@ -379,9 +379,9 @@ As more nodes join the HyperBEAM network:
 
 Explore HyperBEAM's capabilities in detail:
 
-1. **Learn Querying**: [Querying AO Process State](/concepts/decentralized-computing/hyperbeam/querying-ao-state)
-2. **Build Serverless Functions**: [Lua Serverless Functions](/concepts/decentralized-computing/hyperbeam/lua-serverless)  
-3. **Understand Devices**: [HyperBEAM Devices](/concepts/decentralized-computing/hyperbeam/hyperbeam-devices)
+1. **Learn Querying**: [Querying AO Process State](../hyperbeam/getting-ao-state.md)
+2. **Build Serverless Functions**: [Lua Serverless Functions](../hyperbeam/lua-serverless.md)  
+3. **Understand Devices**: [HyperBEAM Devices](../hyperbeam/hyperbeam-devices.md)
 4. **Start Building**: [Builder's Journey](/guides/builder-journey/)
 
 ## Resources

--- a/src/fundamentals/decentralized-computing/index.md
+++ b/src/fundamentals/decentralized-computing/index.md
@@ -100,24 +100,21 @@ HyperBEAM's device architecture allows different computational engines (Lua, Web
 ### 1. Start with AO Processes
 Understand the fundamental building blocks of decentralized computing:
 
-- **[What are AO Processes](/fundamentals/decentralized-computing/ao-processes/what-are-ao-processes)** - Learn the core concepts and architecture
-- **[Process Communication](/fundamentals/decentralized-computing/ao-processes/process-communication)** - Master message passing and inter-process communication
-- **[State Management](/fundamentals/decentralized-computing/ao-processes/state-management)** - Understand persistent state and data consistency
+- **[What are AO Processes](./ao-processes/what-are-ao-processes.md)** - Learn the core concepts and architecture
+- **[State Management](./ao-processes/state-management.md)** - Understand persistent state and data consistency
 
 ### 2. Explore HyperBEAM
 Learn how to interact with and leverage the AO Computer:
 
-- **[HyperBEAM Introduction](/concepts/decentralized-computing/hyperbeam/hyperbeam-introduction)** - Understand the HTTP gateway to AO
-- **[Querying AO Process State](/concepts/decentralized-computing/hyperbeam/querying-ao-state)** - Master the HTTP API for data access
-- **[Lua Serverless Functions](/concepts/decentralized-computing/hyperbeam/lua-serverless)** - Build serverless functions with permanent availability
-- **[HyperBEAM Devices](/concepts/decentralized-computing/hyperbeam/hyperbeam-devices)** - Understand the modular device architecture
+- **[HyperBEAM Introduction](./hyperbeam/hyperbeam-introduction.md)** - Understand the HTTP gateway to AO
+- **[Querying AO Process State](./hyperbeam/getting-ao-state.md)** - Master the HTTP API for data access
+- **[Lua Serverless Functions](./hyperbeam/lua-serverless.md)** - Build serverless functions with permanent availability
+- **[HyperBEAM Devices](./hyperbeam/hyperbeam-devices.md)** - Understand the modular device architecture
 
 ### 3. Build Applications
 Apply your knowledge to real-world projects:
 
-- **[Builder's Journey](/guides/builder-journey/)** - End-to-end development workflow
-- **[Zero-deployed Full Stack App](/getting-started/zero-to-deploy)** - Quick start guide
-- **[Advanced Patterns](/guides/advanced-patterns/)** - Sophisticated application architectures
+- **[Zero-deployed Full Stack App](../../getting-started/zero-to-deploy.md)** - Quick start guide
 
 ## Use Cases
 
@@ -173,9 +170,9 @@ Apply your knowledge to real-world projects:
 - Programming experience (JavaScript/Lua preferred)
 
 ### Quick Start
-1. **Deploy your first process** - [Zero-deployed App Guide](/getting-started/zero-to-deploy)
-2. **Query process state** - [HyperBEAM Querying](/concepts/decentralized-computing/hyperbeam/querying-ao-state)
-3. **Build serverless functions** - [Lua Functions Guide](/concepts/decentralized-computing/hyperbeam/lua-serverless)
+1. **Deploy your first process** - [Zero-deployed App Guide](../../getting-started/zero-to-deploy.md)
+2. **Query process state** - [HyperBEAM Querying](./hyperbeam/getting-ao-state.md)
+3. **Build serverless functions** - [Lua Functions Guide](./hyperbeam/lua-serverless.md)
 
 ### Development Tools
 - **AOS** - AO Studio development environment
@@ -223,4 +220,4 @@ Decentralized computing enables:
 
 ---
 
-**Ready to build?** Start with [What are AO Processes](/fundamentals/decentralized-computing/ao-processes/what-are-ao-processes) to understand the fundamentals, then move to [HyperBEAM Introduction](/concepts/decentralized-computing/hyperbeam/hyperbeam-introduction) to learn how to interact with the AO Computer.
+**Ready to build?** Start with [What are AO Processes](./ao-processes/what-are-ao-processes.md) to understand the fundamentals, then move to [HyperBEAM Introduction](./hyperbeam/hyperbeam-introduction.md) to learn how to interact with the AO Computer.

--- a/src/fundamentals/transactions/arweave-js.md
+++ b/src/fundamentals/transactions/arweave-js.md
@@ -1,0 +1,98 @@
+# Posting Transactions using arweave-js
+
+Arweave native transactions can be posted directly to a node or gateway using the `arweave-js` package.
+
+::: info
+Arweave scales though the use of transaction bundles. These bundles make it possible for each block to contain a nearly unlimited number of transactions. Without the use of bundles, Arweave blocks are limited 1000 transactions per block (with new blocks produced every ~2 minutes). If your use case exceeds this capacity you may experience dropped transactions. Under these circumstances please consider using bundling services to bundle your transactions.
+:::
+
+## Installing the arweave-js Package
+
+To install `arweave-js` run
+<CodeGroup>
+<CodeGroupItem title="NPM">
+
+```console:no-line-numbers
+npm install --save arweave
+```
+
+  </CodeGroupItem>
+  <CodeGroupItem title="YARN">
+
+```console:no-line-numbers
+yarn add arweave
+```
+
+  </CodeGroupItem>
+</CodeGroup>
+
+::: info
+When working with NodeJS a minimum version of NodeJS 18 or higher is required.
+:::
+
+## Initializing arweave-js
+
+Direct Layer 1 transactions are posted using the `arweave-js` library.
+
+```js:no-line-numbers
+import Arweave from 'arweave';
+import fs from "fs";
+
+// load the JWK wallet key file from disk
+let key = JSON.parse(fs.readFileSync("walletFile.txt").toString());
+
+// initialize an arweave instance
+const arweave = Arweave.init({});
+```
+
+## Posting a wallet-to-wallet Transaction
+
+A basic transaction to move AR tokens from one wallet address to another.
+
+```js:no-line-numbers
+//  create a wallet-to-wallet transaction sending 10.5AR to the target address
+let transaction = await arweave.createTransaction({
+  target: '1seRanklLU_1VTGkEk7P0xAwMJfA7owA1JHW5KyZKlY',
+  quantity: arweave.ar.arToWinston('10.5')
+}, key);
+
+// you must sign the transaction with your key before posting
+await arweave.transactions.sign(transaction, key);
+
+// post the transaction
+const response = await arweave.transactions.post(transaction);
+```
+
+## Posting a Data Transaction
+
+This example illustrates how load a file from disk and create a transaction to store its data on the network. You can find the current price the network is charging at [https://ar-fees.arweave.net](https://ar-fees.arweave.net)
+
+```js:no-line-numbers
+// load the data from disk
+const imageData = fs.readFileSync(`iamges/myImage.png`);
+
+// create a data transaction
+let transaction = await arweave.createTransaction({
+  data: imageData
+}, key);
+
+// add a custom tag that tells the gateway how to serve this data to a browser
+transaction.addTag('Content-Type', 'image/png');
+
+// you must sign the transaction with your key before posting
+await arweave.transactions.sign(transaction, key);
+
+// create an uploader that will seed your data to the network
+let uploader = await arweave.transactions.getUploader(transaction);
+
+// run the uploader until it completes the upload.
+while (!uploader.isComplete) {
+  await uploader.uploadChunk();
+}
+```
+
+## Resources
+
+-   For an overview of all the ways you can post transactions, see the [Posting Transactions](./post-transactions.md) section of the cookbook.
+
+-   For a more detailed description of all `arweave-js`'s features see the documentation [on github](https://github.com/ArweaveTeam/arweave-js)

--- a/src/fundamentals/transactions/dispatch.md
+++ b/src/fundamentals/transactions/dispatch.md
@@ -1,0 +1,24 @@
+# Posting a Transaction using Dispatch
+Arweave Browser wallets have the concept of dispatching transactions. If the transaction is under 100KB in size it can be posted for free!
+## Dispatching a Transaction
+This can be done without any package dependencies for the client app. As long as the user has a browser wallet active and the data is less than 100KB, dispatched transactions are free and guaranteed to be confirmed on the network.
+
+```js:no-line-numbers
+// use arweave-js to create a transaction
+let tx = await arweave.createTransaction({ data:"Hello World!" })
+
+// add some custom tags to the transaction
+tx.addTag('App-Name', 'PublicSquare')
+tx.addTag('Content-Type', 'text/plain')
+tx.addTag('Version', '1.0.1')
+tx.addTag('Type', 'post')
+
+// use the browser wallet to dispatch() the transaction
+let result = await window.arweaveWallet.dispatch(tx);
+
+// log out the transactino id
+console.log(result.id);
+```
+
+## Resources
+* For an overview of all the ways you can post transactions, see the [Posting Transactions](./post-transactions.md) section of the cookbook.

--- a/src/fundamentals/transactions/post-transactions.md
+++ b/src/fundamentals/transactions/post-transactions.md
@@ -30,7 +30,7 @@ For the above reasons, developers tend to configure `arweave-js` to point to a g
 
 Gateways sit between clients and Arweave's network of peers. One of the primary functions of the gateway is to index transactions and optimistically cache the data posted to the network while waiting for it to be included in a block. This makes the transaction queryable in a "Pending" state almost instantly which allows applications built on top of a gateway to be more responsive. There is still a risk of transactions dropping out of the optimistic cache if they are not mined in a block by the peers.
 
-An example of how to post a direct transaction using `arweave-js` can be found [in this guide](../guides/posting-transactions/arweave-js.md).
+An example of how to post a direct transaction using `arweave-js` can be found [in this guide](./arweave-js.md).
 
 ## Bundled Transactions
 
@@ -40,10 +40,10 @@ Services built on top of Arweave that provide additional utility for Permaweb bu
 
 Another way to post bundled transactions is from the browser. While browsers enforce some constraints around the size of data that can be uploaded, browser based wallets are able to post transactions to bundlers. Arweave browser wallets implement a `dispatch()` API method. If you are posting small transactions (100KB or less) you can use the wallets `dispatch()` method to take advantage of bundled transactions.
 
-An example of how to post a 100KB or less bundled transaction with an Arweave wallets `dispatch()` method can be found [in this guide](../guides/posting-transactions/dispatch.md).
+An example of how to post a 100KB or less bundled transaction with an Arweave wallets `dispatch()` method can be found [in this guide](./dispatch.md).
 
 ## Resources
 
--   [arweave-js](../guides/posting-transactions/arweave-js.md) example
--   [dispatch](../guides/posting-transactions/dispatch.md) example
--   [Turbo SDK](../guides/posting-transactions/turbo.md) example
+-   [arweave-js](./arweave-js.md) example
+-   [dispatch](./dispatch.md) example
+-   [Turbo SDK](./turbo.md) example

--- a/src/fundamentals/transactions/turbo.md
+++ b/src/fundamentals/transactions/turbo.md
@@ -1,0 +1,121 @@
+# Posting Transactions using Ardrive Turbo
+
+Posting transactions using Turbo can be accomplished using the `@ardrive/turbo-sdk` JavaScript package.
+
+## Installing the @ardrive/turbo-sdk
+
+To install `@ardrive/turbo-sdk` run
+
+<CodeGroup>
+  <CodeGroupItem title="NPM">
+
+```console:no-line-numbers
+npm install @ardrive/turbo-sdk
+```
+
+  </CodeGroupItem>
+  <CodeGroupItem title="YARN">
+
+```console:no-line-numbers
+yarn add @ardrive/turbo-sdk
+```
+
+  </CodeGroupItem>
+</CodeGroup>
+
+## Initializing Turbo Client
+
+There are multiple ways to upload data using the `turbo` sdk. You can:
+
+- upload simple data
+- upload a `file`
+- upload a `data-item`
+
+ArDrive Turbo's documentation provides a quick start for any of these methods. 
+
+The recommended way of posting transactions and uploading data to Arweave is with DataItems.
+
+### Quick Start
+
+```js
+import { ArweaveSigner, TurboFactory } from '@ardrive/turbo-sdk';
+import Arweave from 'arweave';
+import fs from 'fs';
+import open from 'open';
+import path from 'path';
+
+async function uploadWithTurbo() {
+  const jwk = JSON.parse(fs.readFileSync('./my-jwk.json', 'utf-8'));
+  const signer = new ArweaveSigner(jwk);
+  const turbo = TurboFactory.authenticated({ signer });
+
+  try {
+    // upload some simple data - log upload progress events
+    const { id, owner, dataCaches, fastFinalityIndexes } = await turbo.upload({
+      data: 'Hello, world!',
+      events: {
+        // overall events (includes signing and upload events)
+        onProgress: ({ totalBytes, processedBytes, step }) => {
+          console.log('Overall progress:', { totalBytes, processedBytes, step });
+        },
+        onError: ({ error, step }) => {
+          console.log('Overall error:', { error, step });
+        },
+      },
+    });
+
+    // upload a file - log signing and upload progress events
+    const filePath = path.join(__dirname, './my-image.png');
+    const fileSize = fs.statSync(filePath).size;
+    const { id, owner, dataCaches, fastFinalityIndexes } =
+      await turbo.uploadFile({
+        fileStreamFactory: () => fs.createReadStream(filePath),
+        fileSizeFactory: () => fileSize,
+        events: {
+          // overall events (includes signing and upload events)
+          onProgress: ({ totalBytes, processedBytes, step }) => {
+            console.log('Overall progress:', { totalBytes, processedBytes, step });
+          },
+          onError: ({ error, step }) => {
+            console.log('Overall error:', { error, step });
+          },
+          // signing events
+          onSigningProgress: ({ totalBytes, processedBytes }) => {
+            console.log('Signing progress:', { totalBytes, processedBytes });
+          },
+          onSigningError: (error) => {
+            console.log('Signing error:', { error });
+          },
+          onSigningSuccess: () => {
+            console.log('Signing success!');
+          },
+          // upload events
+          onUploadProgress: ({ totalBytes, processedBytes }) => {
+            console.log('Upload progress:', { totalBytes, processedBytes });
+          },
+          onUploadError: (error) => {
+            console.log('Upload error:', { error });
+          },
+          onUploadSuccess: () => {
+            console.log('Upload success!');
+          },
+        },
+      });
+    // upload complete!
+    console.log('Successfully upload data item!', {
+      id,
+      owner,
+      dataCaches,
+      fastFinalityIndexes,
+    });
+  } catch (error) {
+    // upload failed
+    console.error('Failed to upload data item!', error);
+  }
+}
+```
+
+## Resources
+
+- Dive into the [Code](https://github.com/ardriveapp/turbo-sdk)
+- Join the discussion in the [ArDrive Discord](https://discord.com/invite/ya4hf2H)

--- a/src/fundamentals/wallets-and-keyfiles/index.md
+++ b/src/fundamentals/wallets-and-keyfiles/index.md
@@ -4,7 +4,7 @@ Arweave wallets serve as the gateway to interact with the Arweave blockchain net
 
 ## What is an Arweave wallet?
 
-A wallet on Arweave is a cryptographic tool that secures your unique blockchain address. This address tracks your $AR token balance and enables network interactions such as sending transactions or working with [AO Processes](https://ao.arweave.net).
+A wallet on Arweave is a cryptographic tool that secures your unique blockchain address. This address tracks your $AR token balance and enables network interactions such as sending transactions or working with [AO Processes](https://cookbook_ao.ar.io).
 
 It's important to understand that wallets don't actually "hold" tokens. Instead, they store the cryptographic public-private key pair that allows you to sign transactions and manage your on-chain assets. Token balances exist on the blockchain itself, linked to your wallet's address.
 

--- a/src/kits/react/create-react-app.md
+++ b/src/kits/react/create-react-app.md
@@ -4,9 +4,9 @@ This guide will walk you through in a step by step flow to configure your develo
 
 ## Prerequisites
 
--   Basic Typescript Knowledge (Not Mandatory) - [https://www.typescriptlang.org/docs/](Learn Typescript)
--   NodeJS v16.15.0 or greater - [https://nodejs.org/en/download/](Download NodeJS)
--   Knowledge of ReactJS - [https://reactjs.org/](Learn ReactJS)
+-   Basic Typescript Knowledge (Not Mandatory): [Learn Typescript](https://www.typescriptlang.org/docs/)
+-   NodeJS v16.15.0 or greater: [Download NodeJS](https://nodejs.org/en/download/)
+-   Knowledge of ReactJS: [Learn ReactJS](https://reactjs.org/)
 -   Know git and common terminal commands
 
 ## Development Dependencies

--- a/src/tooling/bundlers.md
+++ b/src/tooling/bundlers.md
@@ -4,7 +4,7 @@ With bundling services users can post their data transactions to a bundling serv
 
 ## What is a bundle?
 
-A description of transaction bundles and their benefits can be found [here](/concepts/bundles.md).
+A description of transaction bundles and their benefits can be found [here](../fundamentals/transactions/bundles.md).
 
 Bundles follow the [ANS-104 standard](https://specs.arweave.dev/?tx=xwOgX-MmqN5_-Ny_zNu2A8o-PnTGsoRb_3FrtiMAkuw), which defines how multiple data items can be efficiently packaged together into a single Arweave transaction. This enables:
 

--- a/src/tooling/deployment/index.md
+++ b/src/tooling/deployment/index.md
@@ -51,6 +51,6 @@ Before deploying, ensure you have:
 ## Next Steps
 
 1. **Get Started**: [Permaweb Deploy](permaweb-deploy.md)
-2. **Learn ArNS**: [ArNS Names](/concepts/arns)
-3. **Understand Manifests**: [Manifests & Path Resolution](/concepts/manifests)
+2. **Learn ArNS**: [ArNS Names](../../fundamentals/accessing-arweave-data/arns.md)
+3. **Understand Manifests**: [Manifests & Path Resolution](../../fundamentals/accessing-arweave-data/manifests.md)
 4. **Explore Turbo**: [Turbo SDK](https://docs.ardrive.io/docs/turbo/what-is-turbo.html)

--- a/src/tooling/deployment/permaweb-deploy.md
+++ b/src/tooling/deployment/permaweb-deploy.md
@@ -232,7 +232,7 @@ DEBUG=permaweb-deploy* npm run deploy
 
 ## Next Steps
 
-1. **ArNS Setup**: [ArNS Names](/concepts/arns)
+1. **ArNS Setup**: [ArNS Names](../../fundamentals/accessing-arweave-data/arns.md)
 2. **Turbo Credits**: [Turbo SDK](https://docs.ardrive.io/docs/turbo/what-is-turbo.html)
 3. **GitHub Actions**: [CI/CD Integration](/tooling/deployment/github-action)
 

--- a/src/tooling/graphql/index.md
+++ b/src/tooling/graphql/index.md
@@ -87,4 +87,3 @@ const query = gql`
 1. **Start with ar-gql**: [ar-gql Library](ar-gql.md)
 2. **Learn Querying**: [Querying Arweave](/tooling/querying-arweave.md)
 3. **Advanced Search**: [Goldsky Search Gateway](search-indexing-service.md)
-4. **Explore Examples**: [Zero to Deployed App](/getting-started/zero-to-deploy)

--- a/src/tooling/querying-arweave.md
+++ b/src/tooling/querying-arweave.md
@@ -1,5 +1,5 @@
 # Querying Arweave with GraphQL
-Arweave provides a simple way of querying for transactions and filtering them by [tags](../concepts/tags.md). Arweave GraphQL-compatible indexing services provide endpoints users can post GraphQL queries to, and also provide a playground for trying queries.
+Arweave provides a simple way of querying for transactions and filtering them by tags. Arweave GraphQL-compatible indexing services provide endpoints users can post GraphQL queries to, and also provide a playground for trying queries.
 
 [GraphQL](https://graphql.org) is a flexible query language that services can use to build a customized data schema for clients to query. GraphQL also allows clients to specify which elements of the available data structure they would like to see in the results.
 
@@ -173,8 +173,6 @@ query {
 
 
 ## Resources
-* [Arweave GQL Reference](../../references/gql.md)
-* [ArDB package](./ardb.md)
-* [ar-gql package](./ar-gql.md)
-* [Search Indexing Service](./search-indexing-service.md)
+* [ar-gql package](./graphql/ar-gql.md)
+* [Search Indexing Service](./graphql/search-indexing-service.md)
 


### PR DESCRIPTION
  Fixes several broken links throughout docs including 404 errors in post transactions, accessing data, decentralized computing, bundlers, querying, and deployment